### PR TITLE
WIP

### DIFF
--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -28,11 +28,9 @@ class Plugin : Plugin<Project> {
             if [ "${"$"}darwin" = "true" ]; then
                 JVM_TEMP_FILE=${"$"}BUILD_DIR/$macJvmFile
                 JVM_URL=${cfg.macJvmUrl}
-                JVM_ARCHIVE_RELATIVE_PATH=${cfg.macJvmRelativeArchivePath}
             else
                 JVM_TEMP_FILE=${"$"}BUILD_DIR/$linJvmFile
                 JVM_URL=${cfg.linJvmUrl}
-                JVM_ARCHIVE_RELATIVE_PATH=${cfg.linJvmRelativeArchivePath}
             fi
     
             set -e
@@ -66,7 +64,19 @@ class Plugin : Plugin<Project> {
               echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
             fi
     
-            JAVA_HOME=${"$"}JVM_TARGET_DIR/${"$"}JVM_ARCHIVE_RELATIVE_PATH
+            JAVA_HOME=
+            for d in "${"$"}JVM_TARGET_DIR" "${"$"}JVM_TARGET_DIR"/* ${"$"}JVM_TARGET_DIR/Contents/Home ${"$"}JVM_TARGET_DIR/*/Contents/Home; do
+              if [ -e "${"$"}d/bin/java" ]; then
+                JAVA_HOME="${"$"}d"
+              fi
+            done
+            
+            if [ '!' -e "${"$"}JAVA_HOME/bin/java" ]; then
+              die "Unable to find bin/java under ${"$"}JVM_TARGET_DIR"
+            fi
+            
+            # Make it available for child processes
+            export JAVA_HOME
     
             set +e
             

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -107,7 +107,7 @@ class Plugin : Plugin<Project> {
                     set JVM_TARGET_DIR=%BUILD_DIR%gradle-jvm\${getJvmDirName(cfg.windowsJvmUrl)}\
                     
                     set JVM_TEMP_FILE=$windowsJvmFile
-                    set JVM_URL=${cfg.windowsJvmUrl}
+                    set JVM_URL=${cfg.windowsJvmUrl.replace("%", "%%")}
                     
                     set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
                     

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -8,7 +8,7 @@ import java.security.MessageDigest
 @Suppress("unused")
 class Plugin : Plugin<Project> {
     companion object {
-        private const val winJvmFile = "jvm-windows-x64.zip"
+        private const val windowsJvmFile = "jvm-windows-x64.zip"
         private const val macJvmFile = "jvm-macosx-x64.tar.gz"
         private const val linuxJvmFile = "jvm-linux-x64.tar.gz"
         private const val patchedFileStartMarker = "GRADLE JVM WRAPPER START MARKER"
@@ -32,139 +32,137 @@ class Plugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         val cfg = project.extensions.create(extensionName, PluginExtension::class.java)
-        val unixJvmScript = """
-            # $patchedFileStartMarker
-            BUILD_DIR=${"$"}APP_HOME/build
-    
-            if [ "${"$"}darwin" = "true" ]; then
-                JVM_TEMP_FILE=${"$"}BUILD_DIR/$macJvmFile
-                JVM_URL=${cfg.macJvmUrl}
-                JVM_TARGET_DIR=${"$"}BUILD_DIR/gradle-jvm/${getJvmDirName(cfg.macJvmUrl)}
-            else
-                JVM_TEMP_FILE=${"$"}BUILD_DIR/$linuxJvmFile
-                JVM_URL=${cfg.linuxJvmUrl}
-                JVM_TARGET_DIR=${"$"}BUILD_DIR/gradle-jvm/${getJvmDirName(cfg.linuxJvmUrl)}
-            fi
-    
-            set -e
-    
-            if [ -e "${"$"}JVM_TARGET_DIR/.flag" ] && [ -n "${'$'}(ls "${"$"}JVM_TARGET_DIR")" ] && [ "x${'$'}(cat "${"$"}JVM_TARGET_DIR/.flag")" = "x${"$"}{JVM_URL}" ]; then
-                # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
-                true
-            else
-              warn "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
-    
-              rm -f "${"$"}JVM_TEMP_FILE"
-              mkdir -p "${"$"}BUILD_DIR"
-              if command -v curl >/dev/null 2>&1; then
-                  if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
-                  # shellcheck disable=SC2086
-                  curl ${"$"}CURL_PROGRESS --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
-              elif command -v wget >/dev/null 2>&1; then
-                  if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
-                  wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
-              else
-                  die "ERROR: Please install wget or curl"
-              fi
-    
-              warn "Extracting ${"$"}JVM_TEMP_FILE to ${"$"}JVM_TARGET_DIR"
-              rm -rf "${"$"}JVM_TARGET_DIR"
-              mkdir -p "${"$"}JVM_TARGET_DIR"
-    
-              tar -x -f "${"$"}JVM_TEMP_FILE" -C "${"$"}JVM_TARGET_DIR"
-              rm -f "${"$"}JVM_TEMP_FILE"
-    
-              echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
-            fi
-    
-            JAVA_HOME=
-            for d in "${"$"}JVM_TARGET_DIR" "${"$"}JVM_TARGET_DIR"/* ${"$"}JVM_TARGET_DIR/Contents/Home ${"$"}JVM_TARGET_DIR/*/Contents/Home; do
-              if [ -e "${"$"}d/bin/java" ]; then
-                JAVA_HOME="${"$"}d"
-              fi
-            done
-            
-            if [ '!' -e "${"$"}JAVA_HOME/bin/java" ]; then
-              die "Unable to find bin/java under ${"$"}JVM_TARGET_DIR"
-            fi
-            
-            # Make it available for child processes
-            export JAVA_HOME
-    
-            set +e
-            
-            # $patchedFileEndMarker
-        """.trimIndent() + "\n\n"
-        val winJvmScript = """
-            @rem $patchedFileStartMarker
-
-            setlocal
-
-            set BUILD_DIR=%APP_HOME%build\
-            set JVM_TARGET_DIR=%BUILD_DIR%gradle-jvm\${getJvmDirName(cfg.windowsJvmUrl)}\
-            
-            set JVM_TEMP_FILE=amazon-corretto-11.0.4.11.1-windows-x64.zip
-            set JVM_URL=${cfg.windowsJvmUrl}
-            
-            set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
-            
-            if not exist "%JVM_TARGET_DIR%" MD "%JVM_TARGET_DIR%"
-            
-            if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
-            
-            set /p CURRENT_FLAG=<"%JVM_TARGET_DIR%.flag"
-            if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
-            
-            :downloadAndExtractJvm
-            
-            CD "%BUILD_DIR%"
-            if errorlevel 1 goto fail
-            
-            echo Downloading %JVM_URL% to %BUILD_DIR%%JVM_TEMP_FILE%
-            if exist "%JVM_TEMP_FILE%" DEL /F "%JVM_TEMP_FILE%"
-            "%POWERSHELL%" -nologo -noprofile -Command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%JVM_TEMP_FILE%')"
-            if errorlevel 1 goto fail
-            
-            RMDIR /S /Q "%JVM_TARGET_DIR%"
-            if errorlevel 1 goto fail
-            
-            MKDIR "%JVM_TARGET_DIR%"
-            if errorlevel 1 goto fail
-            
-            CD "%JVM_TARGET_DIR%"
-            if errorlevel 1 goto fail
-            
-            echo Extracting %BUILD_DIR%%JVM_TEMP_FILE% to %JVM_TARGET_DIR%
-            "%POWERSHELL%" -nologo -noprofile -command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('..\\..\\%JVM_TEMP_FILE%', '.');"
-            if errorlevel 1 goto fail
-            
-            DEL /F "..\..\%JVM_TEMP_FILE%"
-            if errorlevel 1 goto fail
-            
-            echo %JVM_URL%>"%JVM_TARGET_DIR%.flag"
-            if errorlevel 1 goto fail
-            
-            :continueWithJvm
-            
-            set JAVA_HOME=
-            for /d %%d in (%JVM_TARGET_DIR%*) do if exist "%%d\bin\java.exe" set JAVA_HOME=%%d
-            if not exist "%JAVA_HOME%\bin\java.exe" (
-              echo Unable to find java.exe under %JVM_TARGET_DIR%
-              goto fail
-            )
-            
-            endlocal & set JAVA_HOME=%JAVA_HOME%
-            
-            @rem $patchedFileEndMarker
-        """.trimIndent() + "\n\n"
         project.tasks.getByName(wrapperTaskName) {
             val task = it as Wrapper
             task.doLast {
+                val unixJvmScript = """
+                    # $patchedFileStartMarker
+                    BUILD_DIR=${"$"}APP_HOME/build
+            
+                    if [ "${"$"}darwin" = "true" ]; then
+                        JVM_TEMP_FILE=${"$"}BUILD_DIR/$macJvmFile
+                        JVM_URL=${cfg.macJvmUrl}
+                        JVM_TARGET_DIR=${"$"}BUILD_DIR/gradle-jvm/${getJvmDirName(cfg.macJvmUrl)}
+                    else
+                        JVM_TEMP_FILE=${"$"}BUILD_DIR/$linuxJvmFile
+                        JVM_URL=${cfg.linuxJvmUrl}
+                        JVM_TARGET_DIR=${"$"}BUILD_DIR/gradle-jvm/${getJvmDirName(cfg.linuxJvmUrl)}
+                    fi
+            
+                    set -e
+            
+                    if [ -e "${"$"}JVM_TARGET_DIR/.flag" ] && [ -n "${'$'}(ls "${"$"}JVM_TARGET_DIR")" ] && [ "x${'$'}(cat "${"$"}JVM_TARGET_DIR/.flag")" = "x${"$"}{JVM_URL}" ]; then
+                        # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
+                        true
+                    else
+                      warn "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
+            
+                      rm -f "${"$"}JVM_TEMP_FILE"
+                      mkdir -p "${"$"}BUILD_DIR"
+                      if command -v curl >/dev/null 2>&1; then
+                          if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
+                          # shellcheck disable=SC2086
+                          curl ${"$"}CURL_PROGRESS --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
+                      elif command -v wget >/dev/null 2>&1; then
+                          if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
+                          wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
+                      else
+                          die "ERROR: Please install wget or curl"
+                      fi
+            
+                      warn "Extracting ${"$"}JVM_TEMP_FILE to ${"$"}JVM_TARGET_DIR"
+                      rm -rf "${"$"}JVM_TARGET_DIR"
+                      mkdir -p "${"$"}JVM_TARGET_DIR"
+            
+                      tar -x -f "${"$"}JVM_TEMP_FILE" -C "${"$"}JVM_TARGET_DIR"
+                      rm -f "${"$"}JVM_TEMP_FILE"
+            
+                      echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
+                    fi
+            
+                    JAVA_HOME=
+                    for d in "${"$"}JVM_TARGET_DIR" "${"$"}JVM_TARGET_DIR"/* ${"$"}JVM_TARGET_DIR/Contents/Home ${"$"}JVM_TARGET_DIR/*/Contents/Home; do
+                      if [ -e "${"$"}d/bin/java" ]; then
+                        JAVA_HOME="${"$"}d"
+                      fi
+                    done
+                    
+                    if [ '!' -e "${"$"}JAVA_HOME/bin/java" ]; then
+                      die "Unable to find bin/java under ${"$"}JVM_TARGET_DIR"
+                    fi
+                    
+                    # Make it available for child processes
+                    export JAVA_HOME
+            
+                    set +e
+                    
+                    # $patchedFileEndMarker
+                """.trimIndent() + "\n\n"
+                        val winJvmScript = """
+                    @rem $patchedFileStartMarker
+        
+                    setlocal
+        
+                    set BUILD_DIR=%APP_HOME%build\
+                    set JVM_TARGET_DIR=%BUILD_DIR%gradle-jvm\${getJvmDirName(cfg.windowsJvmUrl)}\
+                    
+                    set JVM_TEMP_FILE=$windowsJvmFile
+                    set JVM_URL=${cfg.windowsJvmUrl}
+                    
+                    set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
+                    
+                    if not exist "%JVM_TARGET_DIR%" MD "%JVM_TARGET_DIR%"
+                    
+                    if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
+                    
+                    set /p CURRENT_FLAG=<"%JVM_TARGET_DIR%.flag"
+                    if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
+                    
+                    :downloadAndExtractJvm
+                    
+                    CD "%BUILD_DIR%"
+                    if errorlevel 1 goto fail
+                    
+                    echo Downloading %JVM_URL% to %BUILD_DIR%%JVM_TEMP_FILE%
+                    if exist "%JVM_TEMP_FILE%" DEL /F "%JVM_TEMP_FILE%"
+                    "%POWERSHELL%" -nologo -noprofile -Command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%JVM_TEMP_FILE%')"
+                    if errorlevel 1 goto fail
+                    
+                    RMDIR /S /Q "%JVM_TARGET_DIR%"
+                    if errorlevel 1 goto fail
+                    
+                    MKDIR "%JVM_TARGET_DIR%"
+                    if errorlevel 1 goto fail
+                    
+                    CD "%JVM_TARGET_DIR%"
+                    if errorlevel 1 goto fail
+                    
+                    echo Extracting %BUILD_DIR%%JVM_TEMP_FILE% to %JVM_TARGET_DIR%
+                    "%POWERSHELL%" -nologo -noprofile -command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('..\\..\\%JVM_TEMP_FILE%', '.');"
+                    if errorlevel 1 goto fail
+                    
+                    DEL /F "..\..\%JVM_TEMP_FILE%"
+                    if errorlevel 1 goto fail
+                    
+                    echo %JVM_URL%>"%JVM_TARGET_DIR%.flag"
+                    if errorlevel 1 goto fail
+                    
+                    :continueWithJvm
+                    
+                    set JAVA_HOME=
+                    for /d %%d in (%JVM_TARGET_DIR%*) do if exist "%%d\bin\java.exe" set JAVA_HOME=%%d
+                    if not exist "%JAVA_HOME%\bin\java.exe" (
+                      echo Unable to find java.exe under %JVM_TARGET_DIR%
+                      goto fail
+                    )
+                    
+                    endlocal & set JAVA_HOME=%JAVA_HOME%
+                    
+                    @rem $patchedFileEndMarker
+                """.trimIndent() + "\n\n"
+
                 val unixScriptFile = task.scriptFile
                 val winScriptFile = task.batchScript
-
-                println(unixScriptFile)
-                println(winScriptFile)
 
                 val unixScriptFileContent = unixScriptFile.readText(Charsets.UTF_8)
                 if (!unixScriptFileContent.contains(patchedFileStartMarker)) {

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -2,8 +2,6 @@ package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
     var winJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip"
-    var linJvmUrl = "https://repo.labs.intellij.net/cache/https/d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
-    var linJvmRelativeArchivePath = ""
-    var macJvmUrl = "https://repo.labs.intellij.net/cache/https/d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz"
-    var macJvmRelativeArchivePath = "amazon-corretto-11.jdk/Contents/Home"
+    var linJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
+    var macJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz"
 }

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -2,7 +2,6 @@ package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
     var winJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip"
-    var winJvmRelativeArchivePath = "jdk11.0.4_10"
     var linJvmUrl = "https://repo.labs.intellij.net/cache/https/d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
     var linJvmRelativeArchivePath = ""
     var macJvmUrl = "https://repo.labs.intellij.net/cache/https/d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz"

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -1,7 +1,7 @@
 package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
-    var winJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip"
-    var linJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
+    var windowsJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip"
+    var linuxJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
     var macJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz"
 }


### PR DESCRIPTION
- cmd: automatically search directory with java.exe
- cmd: do not create temp file
- sh: automatically search for bin/java
- add unique jvm folder name to save many different jvm versions under build/gradle-jvm
(allows to upgrade jvm version while gradle daemons are running under Windows)