### PR TITLE
customizable build dir

### DIFF
--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -37,7 +37,7 @@ class Plugin : Plugin<Project> {
             project.afterEvaluate {
                 val unixJvmScript = """
                     # $patchedFileStartMarker
-                    BUILD_DIR=${"$"}APP_HOME/build
+                    BUILD_DIR="${"$"}APP_HOME/${cfg.buildDir}"
             
                     if [ "${"$"}darwin" = "true" ]; then
                         JVM_TEMP_FILE=${"$"}BUILD_DIR/$macJvmFile
@@ -45,7 +45,7 @@ class Plugin : Plugin<Project> {
                         JVM_TARGET_DIR=${"$"}BUILD_DIR/gradle-jvm/${getJvmDirName(cfg.macJvmUrl)}
                     elif [ "${"$"}cygwin" = "true" ] || [ "${"$"}msys" = "true" ]; then
                         JVM_TEMP_FILE=${"$"}BUILD_DIR/$windowsJvmFile
-                        JVM_URL=https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip
+                        JVM_URL=${cfg.windowsJvmUrl}
                         JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.windowsJvmUrl)}
                     else
                         JVM_TEMP_FILE=${"$"}BUILD_DIR/$linuxJvmFile
@@ -112,7 +112,7 @@ class Plugin : Plugin<Project> {
         
                     setlocal
         
-                    set BUILD_DIR=%APP_HOME%build\
+                    set BUILD_DIR=%APP_HOME%${cfg.buildDir.replace("/", "\\")}\
                     set JVM_TARGET_DIR=%BUILD_DIR%gradle-jvm\${getJvmDirName(cfg.windowsJvmUrl)}\
                     
                     set JVM_TEMP_FILE=$windowsJvmFile

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -1,6 +1,7 @@
 package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
+	var buildDir = "build"
     var windowsJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-windows-x64.zip"
     var linuxJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-linux-x64.tar.gz"
     var macJvmUrl = "https://d3pxv6yz143wms.cloudfront.net/11.0.4.11.1/amazon-corretto-11.0.4.11.1-macosx-x64.tar.gz"


### PR DESCRIPTION
Changing the default download location away from `build` allows for faster builds after a `clean` or on CI.
Minor: the windows url wasn't set in the gradlew wrapper.