### PR TITLE
Update install directory documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ plugins {
 }
 
 jvmWrapper {
-    jvmInstallDir = "/my-custom-path/gradle-jvm"
+    unixJvmInstallDir = "/my-custom-path/gradle-jvm"
+    winJvmInstallDir = "C:\\my-custom-path\\gradle-jvm"
     linuxAarch64JvmUrl = "https://corretto.aws/downloads/resources/11.0.9.12.1/amazon-corretto-11.0.9.12.1-linux-aarch64.tar.gz"
     linuxX64JvmUrl = "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz"
     macAarch64JvmUrl = "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz"
@@ -38,7 +39,8 @@ plugins {
 }
 
 jvmWrapper {
-    jvmInstallDir = "/my-custom-path/gradle-jvm"
+    unixJvmInstallDir = "/my-custom-path/gradle-jvm"
+    winJvmInstallDir = "C:\\my-custom-path\\gradle-jvm"
     linuxAarch64JvmUrl = "https://corretto.aws/downloads/resources/11.0.9.12.1/amazon-corretto-11.0.9.12.1-linux-aarch64.tar.gz"
     linuxX64JvmUrl = "https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.tar.gz"
     macAarch64JvmUrl = "https://cdn.azul.com/zulu/bin/zulu11.45.27-ca-jdk11.0.10-macosx_aarch64.tar.gz"


### PR DESCRIPTION
@mfilippov, thanks so much for this excellent project.  This was exactly what I needed and wanted for my JVM projects and has been working great.  I discovered this through [this comment you made](https://github.com/gradle/gradle/issues/2508#issuecomment-630116217)—thanks for chiming in there!  Really helped.

Contributing a small change back:

The correct configuration for the install dir uses `unixJvmInstallDir` and `winJvmInstallDir`, rather than just `jvmInstallDir`.  Update the README to reflect this.