### PR TITLE
AArch64 support for Windows

### DIFF
--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -130,9 +130,18 @@ class Plugin : Plugin<Project> {
 
                     setlocal
                     set BUILD_DIR=${cfg.winJvmInstallDir}
-                    set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsX64JvmUrl)}\
 
-                    set JVM_URL=${cfg.windowsX64JvmUrl.replace("%", "%%")}
+                    for /f "tokens=3 delims= " %%A in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "PROCESSOR_ARCHITECTURE"') do set WIN_ARCH=%%A
+                    if "%WIN_ARCH%" equ "AMD64" (
+                        set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsX64JvmUrl)}\
+                        set JVM_URL=${cfg.windowsX64JvmUrl.replace("%", "%%")}
+                    ) else if "%WIN_ARCH%" equ "ARM64" (
+                        set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsAarch64JvmUrl)}\
+                        set JVM_URL=${cfg.windowsAarch64JvmUrl.replace("%", "%%")}
+                    ) else (
+                        echo Unknown architecture %WIN_ARCH%
+                        goto fail
+                    )
                     
                     set IS_TAR_GZ=0
                     set JVM_TEMP_FILE=gradle-jvm.zip

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -3,6 +3,8 @@ package me.filippov.gradle.jvm.wrapper
 open class PluginExtension {
     var winJvmInstallDir: String = "%LOCALAPPDATA%\\gradle-jvm"
     var unixJvmInstallDir: String = "${"$"}{HOME}/.local/share/gradle-jvm"
+    // https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-21
+    var windowsAarch64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-21.0.6-windows-aarch64.zip"
     // https://www.oracle.com/java/technologies/javase/jdk21-archive-downloads.html
     var windowsX64JvmUrl = "https://download.oracle.com/java/21/archive/jdk-21.0.5_windows-x64_bin.zip"
     var linuxAarch64JvmUrl = "https://download.oracle.com/java/21/archive/jdk-21.0.5_linux-aarch64_bin.tar.gz"


### PR DESCRIPTION
Closes #40.

Mind that this is based on #41 (would have to deal with unnecessary conflicts otherwise).