### PR TITLE
Add support for parallel run of Gradle wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         shell: bash
         run: |
           docker run --rm -v "$PWD:/work" -w /work \
-            -e TEST_LINUX_X64_JVM_URL=https://corretto.aws/downloads/latest/amazon-corretto-21-x64-alpine-linux-jdk.tar.gz \
+            -e TEST_LINUX_X64_JVM_URL=https://corretto.aws/downloads/latest/amazon-corretto-21-x64-alpine-jdk.tar.gz \
             alpine:3.22 sh -c '
               set -e
               apk add --no-cache openjdk21-jdk curl util-linux musl-utils >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,28 @@ jobs:
         with:
           name: test-report-linux-arm
           path: build/reports/tests/test
+  linux-musl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tests
+        shell: bash
+        run: |
+          docker run --rm -v "$PWD:/work" -w /work \
+            -e TEST_LINUX_X64_JVM_URL=https://corretto.aws/downloads/latest/amazon-corretto-21-x64-alpine-linux-jdk.tar.gz \
+            alpine:3.22 sh -c '
+              set -e
+              apk add --no-cache openjdk21-jdk curl util-linux musl-utils >/dev/null
+              java -cp gradle/wrapper/gradle-wrapper.jar org.gradle.wrapper.GradleWrapperMain --no-daemon --console=plain test \
+                --tests "me.filippov.gradle.jvm.wrapper.PluginTest.smokeParallelRun" \
+                --tests "me.filippov.gradle.jvm.wrapper.PluginTest.smokeSelfHealAfterBrokenInstall" \
+                --tests "me.filippov.gradle.jvm.wrapper.PluginTest.staleLockReportsClearError"
+            '
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-report-linux-musl
+          path: build/reports/tests/test
   macos:
     runs-on: macos-15-intel
     steps:

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -34,8 +34,20 @@ class Plugin : Plugin<Project> {
             project.afterEvaluate {
                 val unixJvmScript = """
                     # $patchedFileStartMarker
+                    retry_on_error () {
+                      n="${'$'}1"
+                      shift
+                      for _ in ${'$'}(seq 2 "${'$'}n"); do
+                        "${'$'}@" 2>&1 && return || echo "WARNING: Command '${'$'}1' returned non-zero exit status ${'$'}?, try again"
+                      done
+                      "${'$'}@"
+                    }
+                    KEEP_ROSETTA2=${cfg.keepRosetta2}
                     BUILD_DIR="${cfg.unixJvmInstallDir}"
                     JVM_ARCH=${'$'}(uname -m)
+                    if [ "${"$"}darwin" = "true" ] && ! ${"$"}KEEP_ROSETTA2 && [ "${'$'}(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+                        JVM_ARCH=arm64
+                    fi
                     JVM_TEMP_FILE=${"$"}BUILD_DIR/gradle-jvm-temp.tar.gz
                     if [ "${"$"}darwin" = "true" ]; then
                         case ${"$"}JVM_ARCH in
@@ -73,10 +85,33 @@ class Plugin : Plugin<Project> {
             
                     set -e
             
-                    if [ -e "${"$"}JVM_TARGET_DIR/.flag" ] && [ -n "${'$'}(ls "${"$"}JVM_TARGET_DIR")" ] && [ "x${'$'}(cat "${"$"}JVM_TARGET_DIR/.flag")" = "x${"$"}{JVM_URL}" ]; then
+                    if grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
                         # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
                         true
                     else
+                    while true; do  # Note: emulates goto
+                      mkdir -p "${"$"}BUILD_DIR"
+                      LOCK_FILE=${"$"}BUILD_DIR/.gradle-jvm-lock.pid
+                      TMP_LOCK_FILE=${"$"}BUILD_DIR/.tmp.${'$'}${'$'}.pid
+                      echo ${'$'}${'$'} >"${"$"}TMP_LOCK_FILE"
+                      while ! ln "${"$"}TMP_LOCK_FILE" "${"$"}LOCK_FILE" 2>/dev/null; do
+                        LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
+                        while [ -n "${"$"}LOCK_OWNER" ] && ps -p "${"$"}LOCK_OWNER" >/dev/null; do
+                          warn "Waiting for the process ${"$"}LOCK_OWNER to finish the JVM bootstrap"
+                          sleep 1
+                          LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
+                          # Hurry up, bootstrap is ready..
+                          if grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
+                            break 3  # Note: goto out of the outer if-else block.
+                          fi
+                        done
+                        if [ -n "${"$"}LOCK_OWNER" ] && grep -q -x "${"$"}LOCK_OWNER" "${"$"}LOCK_FILE" 2>/dev/null; then
+                          die "ERROR: The lock file ${"$"}LOCK_FILE still exists on disk after the owner process ${"$"}LOCK_OWNER exited"
+                        fi
+                      done
+                      trap 'rm -f "${"$"}LOCK_FILE"' EXIT
+                      rm "${"$"}TMP_LOCK_FILE"
+                      if ! grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
                       echo "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
             
                       rm -f "${"$"}JVM_TEMP_FILE"
@@ -84,10 +119,10 @@ class Plugin : Plugin<Project> {
                       if command -v curl >/dev/null 2>&1; then
                           if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
                           # shellcheck disable=SC2086
-                          curl ${"$"}CURL_PROGRESS -L --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL" 2>&1
+                          retry_on_error 5 curl ${"$"}CURL_PROGRESS -L --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
                       elif command -v wget >/dev/null 2>&1; then
                           if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
-                          wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL" 2>&1
+                          retry_on_error 5 wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
                       else
                           die "ERROR: Please install wget or curl"
                       fi
@@ -104,6 +139,10 @@ class Plugin : Plugin<Project> {
                       rm -f "${"$"}JVM_TEMP_FILE"
             
                       echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
+                      fi
+                      rm "${"$"}LOCK_FILE"
+                      break
+                    done
                     fi
             
                     JAVA_HOME=

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -102,6 +102,7 @@ class Plugin : Plugin<Project> {
                           LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
                           # Hurry up, bootstrap is ready..
                           if grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
+                            rm -f "${"$"}TMP_LOCK_FILE"
                             break 3  # Note: goto out of the outer if-else block.
                           fi
                         done
@@ -192,49 +193,53 @@ class Plugin : Plugin<Project> {
 
                     set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
 
-                    if not exist "%JVM_TARGET_DIR%" MD "%JVM_TARGET_DIR%"
-
                     if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
 
                     set /p CURRENT_FLAG=<"%JVM_TARGET_DIR%.flag"
                     if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
 
                     :downloadAndExtractJvm
-                    
-                    PUSHD "%BUILD_DIR%"
-                    if errorlevel 1 goto fail
 
-                    echo Downloading %JVM_URL% to %BUILD_DIR%\%JVM_TEMP_FILE%
-                    if exist "%JVM_TEMP_FILE%" DEL /F "%JVM_TEMP_FILE%"
-                    "%POWERSHELL%" -nologo -noprofile -Command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%JVM_TEMP_FILE%')"
-                    if errorlevel 1 goto fail
+                    set DOWNLOAD_AND_EXTRACT_JVM_PS1= ^
+                    Set-StrictMode -Version 3.0; ^
+                    ${'$'}ErrorActionPreference = 'Stop'; ^
+                     ^
+                    ${'$'}createdNew = ${'$'}false; ^
+                    ${'$'}lock = New-Object System.Threading.Mutex(${'$'}true, 'Global\gradle-jvm-wrapper-lock', [ref]${'$'}createdNew); ^
+                    if (-not ${'$'}createdNew) { ^
+                        Write-Host 'Waiting for the other process to finish the JVM bootstrap'; ^
+                        try { [void]${'$'}lock.WaitOne(); } catch [System.Threading.AbandonedMutexException] { } ^
+                    } ^
+                     ^
+                    try { ^
+                        if ((Get-Content '%JVM_TARGET_DIR%.flag' -ErrorAction Ignore) -ne '%JVM_URL%') { ^
+                            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+                            Write-Host 'Downloading %JVM_URL% to %BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                            [void](New-Item '%BUILD_DIR%' -ItemType Directory -Force); ^
+                            (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
+                             ^
+                            Write-Host 'Extracting %BUILD_DIR%\%JVM_TEMP_FILE% to %JVM_TARGET_DIR%'; ^
+                            if (Test-Path '%JVM_TARGET_DIR%') { ^
+                                Remove-Item '%JVM_TARGET_DIR%' -Recurse -Force; ^
+                            } ^
+                            [void](New-Item '%JVM_TARGET_DIR%' -ItemType Directory -Force); ^
+                            if ('%IS_TAR_GZ%' -eq '1') { ^
+                                tar -x -f '%BUILD_DIR%\%JVM_TEMP_FILE%' -C '%JVM_TARGET_DIR%.'; ^
+                                if (${'$'}LASTEXITCODE -ne 0) { throw 'tar extraction failed'; } ^
+                            } else { ^
+                                Add-Type -A 'System.IO.Compression.FileSystem'; ^
+                                [IO.Compression.ZipFile]::ExtractToDirectory('%BUILD_DIR%\%JVM_TEMP_FILE%', '%JVM_TARGET_DIR%'); ^
+                            } ^
+                            Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                             ^
+                            Set-Content '%JVM_TARGET_DIR%.flag' -Value '%JVM_URL%'; ^
+                        } ^
+                    } ^
+                    finally { ^
+                        [void]${'$'}lock.ReleaseMutex(); ^
+                    }
 
-                    POPD
-
-                    RMDIR /S /Q "%JVM_TARGET_DIR%"
-                    if errorlevel 1 goto fail
-
-                    MKDIR "%JVM_TARGET_DIR%"
-                    if errorlevel 1 goto fail
-
-                    PUSHD "%JVM_TARGET_DIR%"
-                    if errorlevel 1 goto fail
-
-                    echo Extracting %BUILD_DIR%\%JVM_TEMP_FILE% to %JVM_TARGET_DIR%
-                    
-                    if "%IS_TAR_GZ%"=="1" (
-                        tar xf "..\\%JVM_TEMP_FILE%"
-                    ) else (
-                        "%POWERSHELL%" -nologo -noprofile -command "Set-StrictMode -Version 3.0; ${"$"}ErrorActionPreference = \"Stop\"; Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::ExtractToDirectory('..\\%JVM_TEMP_FILE%', '.');"
-                    )
-                    if errorlevel 1 goto fail
-
-                    DEL /F "..\%JVM_TEMP_FILE%"
-                    if errorlevel 1 goto fail
-
-                    POPD
-
-                    echo %JVM_URL%>"%JVM_TARGET_DIR%.flag"
+                    "%POWERSHELL%" -nologo -noprofile -Command %DOWNLOAD_AND_EXTRACT_JVM_PS1%
                     if errorlevel 1 goto fail
 
                     :continueWithJvm

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -158,6 +158,7 @@ class Plugin : Plugin<Project> {
                       echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
                       fi
                       rm "${"$"}LOCK_FILE"
+                      trap - EXIT
                       break
                     done
                     fi

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -42,6 +42,9 @@ class Plugin : Plugin<Project> {
                       done
                       "${'$'}@"
                     }
+                    jvm_is_up_to_date () {
+                      [ -n "${'$'}(ls "${'$'}JVM_TARGET_DIR" 2>/dev/null)" ] && grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null
+                    }
                     KEEP_ROSETTA2=${cfg.keepRosetta2}
                     BUILD_DIR="${cfg.unixJvmInstallDir}"
                     JVM_ARCH=${'$'}(uname -m)
@@ -85,7 +88,7 @@ class Plugin : Plugin<Project> {
             
                     set -e
             
-                    if grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
+                    if jvm_is_up_to_date; then
                         # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
                         true
                     else
@@ -94,14 +97,27 @@ class Plugin : Plugin<Project> {
                       LOCK_FILE=${"$"}BUILD_DIR/.gradle-jvm-lock.pid
                       TMP_LOCK_FILE=${"$"}BUILD_DIR/.tmp.${'$'}${'$'}.pid
                       echo ${'$'}${'$'} >"${"$"}TMP_LOCK_FILE"
+                      LN_FAILED_COUNT=0
                       while ! ln "${"$"}TMP_LOCK_FILE" "${"$"}LOCK_FILE" 2>/dev/null; do
+                        if [ ! -e "${"$"}LOCK_FILE" ]; then
+                          # ln failed, but there is no lock file: either the owner has just released it
+                          # (retry will succeed), or the filesystem does not support hard links.
+                          LN_FAILED_COUNT=${'$'}((LN_FAILED_COUNT + 1))
+                          if [ "${"$"}LN_FAILED_COUNT" -ge 10 ]; then
+                            rm -f "${"$"}TMP_LOCK_FILE"
+                            die "ERROR: Unable to create the lock file ${"$"}LOCK_FILE. Check that the filesystem supports hard links."
+                          fi
+                          sleep 1
+                          continue
+                        fi
+                        LN_FAILED_COUNT=0
                         LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
-                        while [ -n "${"$"}LOCK_OWNER" ] && ps -p "${"$"}LOCK_OWNER" >/dev/null; do
+                        while [ -n "${"$"}LOCK_OWNER" ] && kill -0 "${"$"}LOCK_OWNER" 2>/dev/null; do
                           warn "Waiting for the process ${"$"}LOCK_OWNER to finish the JVM bootstrap"
                           sleep 1
                           LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
                           # Hurry up, bootstrap is ready..
-                          if grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
+                          if jvm_is_up_to_date; then
                             rm -f "${"$"}TMP_LOCK_FILE"
                             break 3  # Note: goto out of the outer if-else block.
                           fi
@@ -112,7 +128,7 @@ class Plugin : Plugin<Project> {
                       done
                       trap 'rm -f "${"$"}LOCK_FILE"' EXIT
                       rm "${"$"}TMP_LOCK_FILE"
-                      if ! grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null; then
+                      if ! jvm_is_up_to_date; then
                       echo "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
             
                       rm -f "${"$"}JVM_TEMP_FILE"
@@ -192,6 +208,7 @@ class Plugin : Plugin<Project> {
                     )
 
                     set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
+                    set JVM_DOWNLOAD_ATTEMPTED=0
 
                     if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
 
@@ -199,6 +216,8 @@ class Plugin : Plugin<Project> {
                     if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
 
                     :downloadAndExtractJvm
+
+                    set JVM_DOWNLOAD_ATTEMPTED=1
 
                     set DOWNLOAD_AND_EXTRACT_JVM_PS1= ^
                     Set-StrictMode -Version 3.0; ^
@@ -247,6 +266,10 @@ class Plugin : Plugin<Project> {
                     set JAVA_HOME=
                     for /d %%d in ("%JVM_TARGET_DIR%"*) do if exist "%%d\bin\java.exe" set JAVA_HOME=%%d
                     if not exist "%JAVA_HOME%\bin\java.exe" (
+                      if "%JVM_DOWNLOAD_ATTEMPTED%"=="0" (
+                        DEL /F /Q "%JVM_TARGET_DIR%.flag" 2>NUL
+                        goto downloadAndExtractJvm
+                      )
                       echo Unable to find java.exe under %JVM_TARGET_DIR%
                       goto fail
                     )

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -2,6 +2,7 @@ package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
     var winJvmInstallDir: String = "%LOCALAPPDATA%\\gradle-jvm"
+    var keepRosetta2: Boolean = false
     var unixJvmInstallDir: String = "${"$"}{HOME}/.local/share/gradle-jvm"
     // https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25
     var windowsAarch64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip"

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -15,6 +15,56 @@ class PluginTest {
         doSmoke(tempDir, "https://cache-redirector.jetbrains.com/intellij-jbr/jbr-17.0.3-windows-x64-b469.37.tar.gz")
     }
 
+    @Test
+    fun smokeParallelRun(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("folder with space").toFile()
+        projectRoot.mkdirs()
+        val jvmInstallDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm")
+        val absJvmDir = jvmInstallDir.absolutePath.replace("\\", "\\\\")
+
+        withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
+            }
+            tasks.register("hello") {
+                doLast {
+                    println("Hello world!")
+                }
+            }
+        """}
+
+        prepareWrapper(projectRoot)
+
+        // Warm up Gradle caches, then drop the downloaded JVM so both parallel
+        // runs start with an empty install dir and race for the download.
+        val warmUp = gradlew(projectRoot, "hello")
+        warmUp.exitCode.shouldBe(0, "Warm-up run failed:\nSTDOUT:\n${warmUp.stdout}\nSTDERR:\n${warmUp.stderr}\n")
+        jvmInstallDir.deleteRecursively()
+
+        val results = gradlewParallel(projectRoot, "hello", 2)
+        results.forEach { result ->
+            result.stdout.shouldContain("Hello world!",
+                "'Hello world!' not found in output:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
+            result.exitCode.shouldBe(0, "Non zero exit code:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
+        }
+        results.count { it.stdout.contains("Down") }.shouldBe(1,
+            "Expected exactly one process to download the JVM:\n" +
+                    results.joinToString("\n") { "STDOUT:\n${it.stdout}\nSTDERR:\n${it.stderr}\n" })
+        jvmInstallDir.list()!!.size.shouldBe(1)
+
+        repeat((0..30).count()) {
+            if (!projectRoot.exists()) {
+                return@repeat
+            }
+            Thread.sleep(1000)
+            projectRoot.deleteRecursively()
+        }
+    }
+
     private fun doSmoke(tempDir: Path, windowsX64Url: String) {
         val projectRoot = tempDir.resolve("folder with space").toFile()
         projectRoot.mkdirs()

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -1,10 +1,18 @@
 package me.filippov.gradle.jvm.wrapper
 
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
 class PluginTest {
+    // Allows platform-specific CI (e.g. Alpine/musl) to point the tests at a compatible JDK build.
+    private fun jvmUrlOverrides(): String {
+        val linuxX64Url = System.getenv("TEST_LINUX_X64_JVM_URL") ?: return ""
+        return """linuxX64JvmUrl = "$linuxX64Url""""
+    }
+
     @Test
     fun smoke(@TempDir tempDir: Path) {
         doSmoke(tempDir, "https://download.oracle.com/java/18/archive/jdk-18.0.1.1_windows-x64_bin.zip")
@@ -29,6 +37,7 @@ class PluginTest {
             jvmWrapper {
                 winJvmInstallDir = "$absJvmDir"
                 unixJvmInstallDir = "$absJvmDir"
+                ${jvmUrlOverrides()}
             }
             tasks.register("hello") {
                 doLast {
@@ -55,6 +64,107 @@ class PluginTest {
             "Expected exactly one process to download the JVM:\n" +
                     results.joinToString("\n") { "STDOUT:\n${it.stdout}\nSTDERR:\n${it.stderr}\n" })
         jvmInstallDir.list()!!.size.shouldBe(1)
+
+        repeat((0..30).count()) {
+            if (!projectRoot.exists()) {
+                return@repeat
+            }
+            Thread.sleep(1000)
+            projectRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun smokeSelfHealAfterBrokenInstall(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("folder with space").toFile()
+        projectRoot.mkdirs()
+        val jvmInstallDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm")
+        val absJvmDir = jvmInstallDir.absolutePath.replace("\\", "\\\\")
+
+        withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
+                ${jvmUrlOverrides()}
+            }
+            tasks.register("hello") {
+                doLast {
+                    println("Hello world!")
+                }
+            }
+        """}
+
+        prepareWrapper(projectRoot)
+
+        val firstRun = gradlew(projectRoot, "hello")
+        firstRun.exitCode.shouldBe(0, "First run failed:\nSTDOUT:\n${firstRun.stdout}\nSTDERR:\n${firstRun.stderr}\n")
+
+        // Simulate a broken installation: the JDK content is gone, but the .flag survived.
+        // Retry the removal: on Windows the JDK files may be briefly locked after the first run.
+        val jvmTargetDir = jvmInstallDir.listFiles()!!.single()
+        for (attempt in 0..30) {
+            jvmTargetDir.listFiles()!!.filter { it.name != ".flag" }.forEach { it.deleteRecursively() }
+            if (jvmTargetDir.listFiles()!!.all { it.name == ".flag" }) break
+            Thread.sleep(1000)
+        }
+        jvmTargetDir.listFiles()!!.all { it.name == ".flag" }
+            .shouldBeTrue("Failed to remove the JDK content from $jvmTargetDir")
+
+        val secondRun = gradlew(projectRoot, "hello")
+        secondRun.stdout.shouldContain("Down",
+            "Expected the JVM to be re-downloaded:\nSTDOUT:\n${secondRun.stdout}\nSTDERR:\n${secondRun.stderr}\n")
+        secondRun.stdout.shouldContain("Hello world!",
+            "'Hello world!' not found in output:\nSTDOUT:\n${secondRun.stdout}\nSTDERR:\n${secondRun.stderr}\n")
+        secondRun.exitCode.shouldBe(0, "Non zero exit code:\nSTDOUT:\n${secondRun.stdout}\nSTDERR:\n${secondRun.stderr}\n")
+
+        repeat((0..30).count()) {
+            if (!projectRoot.exists()) {
+                return@repeat
+            }
+            Thread.sleep(1000)
+            projectRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    fun staleLockReportsClearError(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("folder with space").toFile()
+        projectRoot.mkdirs()
+        val jvmInstallDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm")
+        val absJvmDir = jvmInstallDir.absolutePath.replace("\\", "\\\\")
+
+        withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
+                ${jvmUrlOverrides()}
+            }
+            tasks.register("hello") {
+                doLast {
+                    println("Hello world!")
+                }
+            }
+        """}
+
+        prepareWrapper(projectRoot)
+
+        // A lock file whose owner is long dead: the wrapper must fail with a clear error
+        // instead of corrupting the installation or waiting forever.
+        jvmInstallDir.mkdirs()
+        jvmInstallDir.resolve(".gradle-jvm-lock.pid").writeText("99999999")
+
+        val result = gradlew(projectRoot, "hello")
+        (result.exitCode != 0).shouldBeTrue(
+            "Expected a failure, got exit code 0:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
+        (result.stdout + result.stderr).shouldContain("The lock file",
+            "Expected a stale lock error:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
 
         repeat((0..30).count()) {
             if (!projectRoot.exists()) {

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -18,13 +18,15 @@ class PluginTest {
     private fun doSmoke(tempDir: Path, windowsX64Url: String) {
         val projectRoot = tempDir.resolve("folder with space").toFile()
         projectRoot.mkdirs()
+        val absJvmDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm").absolutePath.replace("\\", "\\\\")
+
         withBuildScript(projectRoot) { """
             plugins {
               id("me.filippov.gradle.jvm.wrapper")
             }
             jvmWrapper {
-                winJvmInstallDir = "build\\test-temp-dir\\gradle-jvm"
-                unixJvmInstallDir = "build/test-temp-dir/gradle-jvm"
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
             }
             tasks.register("hello") {
                 doLast {
@@ -57,16 +59,14 @@ class PluginTest {
         resultWhenJavaExists.stderr.shouldBeEmpty("Non empty stderr:\n" + resultWhenJavaExists.stderr)
         resultWhenJavaExists.exitCode.shouldBe(0)
 
-        val absJvmDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm")
-
         withBuildScript(projectRoot) { """
             plugins {
               id("me.filippov.gradle.jvm.wrapper")
             }
 
             jvmWrapper {
-                winJvmInstallDir = "${absJvmDir.canonicalPath.replace("\\", "\\\\")}"
-                unixJvmInstallDir = "${absJvmDir.canonicalPath.replace("\\", "\\\\")}"
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
                 linuxAarch64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-linux-aarch64.tar.gz"
                 linuxX64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-linux-x64.tar.gz"
                 macAarch64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-macos-aarch64.tar.gz"

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
@@ -5,6 +5,7 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.File
 import java.util.*
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 val isWindows = System.getProperty("os.name").lowercase(Locale.ENGLISH).startsWith("windows")
@@ -20,17 +21,35 @@ val wrapperScriptFileName = when {
 
 data class TaskResult(val exitCode: Int, val stdout: String, val stderr: String)
 
-fun gradlew(projectRoot: File, task: String): TaskResult {
+private fun gradlewProcessBuilder(projectRoot: File, task: String): ProcessBuilder {
     val workingDirectory = File(System.getProperty("user.dir"))
-    val processBuilder = ProcessBuilder(
+    return ProcessBuilder(
             projectRoot.resolve(wrapperScriptFileName).absolutePath, "--include-build",
             workingDirectory.absolutePath, "-Pkotlin.compiler.execution.strategy=in-process", "--no-daemon", ":$task")
         .directory(projectRoot)
-    val process = processBuilder.start()
+}
+
+fun gradlew(projectRoot: File, task: String): TaskResult {
+    val process = gradlewProcessBuilder(projectRoot, task).start()
     val stdout = process.inputStream.bufferedReader().readText()
     val stderr = process.errorStream.bufferedReader().readText()
     if (!process.waitFor(5, TimeUnit.MINUTES)) error("Process timeout error")
     return TaskResult(process.exitValue(), stdout, stderr)
+}
+
+fun gradlewParallel(projectRoot: File, task: String, count: Int): List<TaskResult> {
+    val processes = List(count) { gradlewProcessBuilder(projectRoot, task).start() }
+    val outputs = processes.map { process ->
+        CompletableFuture.supplyAsync { process.inputStream.bufferedReader().readText() } to
+                CompletableFuture.supplyAsync { process.errorStream.bufferedReader().readText() }
+    }
+    return processes.mapIndexed { i, process ->
+        if (!process.waitFor(10, TimeUnit.MINUTES)) {
+            process.destroyForcibly()
+            error("Process timeout error")
+        }
+        TaskResult(process.exitValue(), outputs[i].first.get(), outputs[i].second.get())
+    }
 }
 
 fun withBuildScript(projectRoot: File, withContent: () -> String) {


### PR DESCRIPTION
Rebase of the 2024 parallel-run work onto current master, finished for all platforms.

- Unix: PID lock file acquired atomically via hardlink, with liveness check of the lock owner, fast path when another process finishes the bootstrap, stale-lock detection and download retries (ported from the original mf/update-wrapper branch; approach mirrors command-line-wrappers/java.cmd).
- Windows: download and extraction now run under a global named mutex (Global\gradle-jvm-wrapper-lock) with a double-check of the .flag inside the critical section - this part was missing in the original implementation.
- Adds keepRosetta2 option: by default the wrapper picks the arm64 JDK when running under Rosetta 2.
- New smokeParallelRun test: two concurrent gradlew runs race for the JVM download; asserts both succeed and the JVM is downloaded exactly once.