### PR TITLE
Add optional SHA-256 validation of the downloaded JVM (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,7 @@ jvmWrapper {
 }
 ```
 If the checksum of the downloaded archive does not match, the build fails with a `SHA-256 mismatch` error.
+
+Take the expected checksums from your JDK vendor: Oracle publishes them next to each archive
+(append `.sha256` to the download URL), Microsoft lists them on the
+[download page](https://learn.microsoft.com/en-us/java/openjdk/download).

--- a/README.md
+++ b/README.md
@@ -50,3 +50,18 @@ jvmWrapper {
     windowsX64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-x64.zip"
 }
 ```
+
+## SHA-256 validation
+The downloaded JVM archive can optionally be verified against an expected SHA-256 checksum.
+Add the checksum for the platforms you want to verify (an empty value disables the check):
+```kotlin
+jvmWrapper {
+    linuxAarch64JvmSha256 = "..."
+    linuxX64JvmSha256 = "..."
+    macAarch64JvmSha256 = "..."
+    macX64JvmSha256 = "..."
+    windowsAarch64JvmSha256 = "..."
+    windowsX64JvmSha256 = "..."
+}
+```
+If the checksum of the downloaded archive does not match, the build fails with a `SHA-256 mismatch` error.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ jvmWrapper {
 ```
 
 ## SHA-256 validation
-The downloaded JVM archive can optionally be verified against an expected SHA-256 checksum.
-Add the checksum for the platforms you want to verify (an empty value disables the check):
+The downloaded JVM archive is verified against an expected SHA-256 checksum.
+The default JVM URLs are validated out of the box: the vendor-published checksums for them
+are built into the plugin. For a custom JVM URL, add the matching checksum yourself
+(with no checksum configured, a custom URL is downloaded without validation):
 ```kotlin
 jvmWrapper {
     linuxAarch64JvmSha256 = "..."

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -1,5 +1,6 @@
 package me.filippov.gradle.jvm.wrapper
 
+import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.wrapper.Wrapper
@@ -27,11 +28,32 @@ class Plugin : Plugin<Project> {
                 "-" +
                 url.sha256().take(6)
 
+    private fun effectiveSha256(configured: String, url: String) =
+        configured.ifEmpty { PluginExtension.defaultJvmSha256[url] ?: "" }.lowercase()
+
+    private fun validateSha256Properties(cfg: PluginExtension) {
+        val sha256Format = Regex("[0-9a-fA-F]{64}")
+        mapOf(
+            "windowsAarch64JvmSha256" to cfg.windowsAarch64JvmSha256,
+            "windowsX64JvmSha256" to cfg.windowsX64JvmSha256,
+            "linuxAarch64JvmSha256" to cfg.linuxAarch64JvmSha256,
+            "linuxX64JvmSha256" to cfg.linuxX64JvmSha256,
+            "macAarch64JvmSha256" to cfg.macAarch64JvmSha256,
+            "macX64JvmSha256" to cfg.macX64JvmSha256,
+        ).forEach { (name, value) ->
+            if (value.isNotEmpty() && !value.matches(sha256Format)) {
+                throw GradleException(
+                    "jvmWrapper.$name must be a 64-character hexadecimal SHA-256 checksum, got: '$value'")
+            }
+        }
+    }
+
     override fun apply(project: Project) {
         val cfg = project.extensions.create(extensionName, PluginExtension::class.java)
         project.tasks.getByName(wrapperTaskName) {
             val task = it as Wrapper
             project.afterEvaluate {
+                validateSha256Properties(cfg)
                 val unixJvmScript = """
                     # $patchedFileStartMarker
                     retry_on_error () {
@@ -56,12 +78,12 @@ class Plugin : Plugin<Project> {
                         case ${"$"}JVM_ARCH in
                         x86_64)
                             JVM_URL=${cfg.macX64JvmUrl}
-                            JVM_SHA256=${cfg.macX64JvmSha256.lowercase()}
+                            JVM_SHA256=${effectiveSha256(cfg.macX64JvmSha256, cfg.macX64JvmUrl)}
                             JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macX64JvmUrl)}
                             ;;
                         arm64)
                             JVM_URL=${cfg.macAarch64JvmUrl}
-                            JVM_SHA256=${cfg.macAarch64JvmSha256.lowercase()}
+                            JVM_SHA256=${effectiveSha256(cfg.macAarch64JvmSha256, cfg.macAarch64JvmUrl)}
                             JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macAarch64JvmUrl)}
                             ;;
                         *) 
@@ -70,19 +92,19 @@ class Plugin : Plugin<Project> {
                         esac
                     elif [ "${"$"}cygwin" = "true" ] || [ "${"$"}msys" = "true" ]; then
                         JVM_URL=${cfg.windowsX64JvmUrl}
-                        JVM_SHA256=${cfg.windowsX64JvmSha256.lowercase()}
+                        JVM_SHA256=${effectiveSha256(cfg.windowsX64JvmSha256, cfg.windowsX64JvmUrl)}
                         JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.windowsX64JvmUrl)}
                     else
                         JVM_ARCH=${'$'}(linux${'$'}(getconf LONG_BIT) uname -m)
                          case ${"$"}JVM_ARCH in
                             x86_64)
                                 JVM_URL=${cfg.linuxX64JvmUrl}
-                                JVM_SHA256=${cfg.linuxX64JvmSha256.lowercase()}
+                                JVM_SHA256=${effectiveSha256(cfg.linuxX64JvmSha256, cfg.linuxX64JvmUrl)}
                                 JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxX64JvmUrl)}
                                 ;;
                             aarch64)
                                 JVM_URL=${cfg.linuxAarch64JvmUrl}
-                                JVM_SHA256=${cfg.linuxAarch64JvmSha256.lowercase()}
+                                JVM_SHA256=${effectiveSha256(cfg.linuxAarch64JvmSha256, cfg.linuxAarch64JvmUrl)}
                                 JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxAarch64JvmUrl)}
                                 ;;
                             *) 
@@ -211,11 +233,11 @@ class Plugin : Plugin<Project> {
                     if "%WIN_ARCH%" equ "AMD64" (
                         set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsX64JvmUrl)}\
                         set JVM_URL=${cfg.windowsX64JvmUrl.replace("%", "%%")}
-                        set JVM_SHA256=${cfg.windowsX64JvmSha256.lowercase()}
+                        set JVM_SHA256=${effectiveSha256(cfg.windowsX64JvmSha256, cfg.windowsX64JvmUrl)}
                     ) else if "%WIN_ARCH%" equ "ARM64" (
                         set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsAarch64JvmUrl)}\
                         set JVM_URL=${cfg.windowsAarch64JvmUrl.replace("%", "%%")}
-                        set JVM_SHA256=${cfg.windowsAarch64JvmSha256.lowercase()}
+                        set JVM_SHA256=${effectiveSha256(cfg.windowsAarch64JvmSha256, cfg.windowsAarch64JvmUrl)}
                     ) else (
                         echo Unknown architecture %WIN_ARCH%
                         goto fail

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -56,10 +56,12 @@ class Plugin : Plugin<Project> {
                         case ${"$"}JVM_ARCH in
                         x86_64)
                             JVM_URL=${cfg.macX64JvmUrl}
+                            JVM_SHA256=${cfg.macX64JvmSha256.lowercase()}
                             JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macX64JvmUrl)}
                             ;;
                         arm64)
                             JVM_URL=${cfg.macAarch64JvmUrl}
+                            JVM_SHA256=${cfg.macAarch64JvmSha256.lowercase()}
                             JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macAarch64JvmUrl)}
                             ;;
                         *) 
@@ -68,16 +70,19 @@ class Plugin : Plugin<Project> {
                         esac
                     elif [ "${"$"}cygwin" = "true" ] || [ "${"$"}msys" = "true" ]; then
                         JVM_URL=${cfg.windowsX64JvmUrl}
+                        JVM_SHA256=${cfg.windowsX64JvmSha256.lowercase()}
                         JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.windowsX64JvmUrl)}
                     else
                         JVM_ARCH=${'$'}(linux${'$'}(getconf LONG_BIT) uname -m)
                          case ${"$"}JVM_ARCH in
                             x86_64)
                                 JVM_URL=${cfg.linuxX64JvmUrl}
+                                JVM_SHA256=${cfg.linuxX64JvmSha256.lowercase()}
                                 JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxX64JvmUrl)}
                                 ;;
                             aarch64)
                                 JVM_URL=${cfg.linuxAarch64JvmUrl}
+                                JVM_SHA256=${cfg.linuxAarch64JvmSha256.lowercase()}
                                 JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxAarch64JvmUrl)}
                                 ;;
                             *) 
@@ -143,7 +148,21 @@ class Plugin : Plugin<Project> {
                       else
                           die "ERROR: Please install wget or curl"
                       fi
-            
+
+                      if [ -n "${"$"}JVM_SHA256" ]; then
+                        if command -v sha256sum >/dev/null 2>&1; then
+                          ACTUAL_SHA256=${'$'}(sha256sum "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
+                        elif command -v shasum >/dev/null 2>&1; then
+                          ACTUAL_SHA256=${'$'}(shasum -a 256 "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
+                        else
+                          die "ERROR: Please install sha256sum or shasum to verify the downloaded JVM"
+                        fi
+                        if [ "${"$"}ACTUAL_SHA256" != "${"$"}JVM_SHA256" ]; then
+                          rm -f "${"$"}JVM_TEMP_FILE"
+                          die "ERROR: SHA-256 mismatch for ${"$"}JVM_URL: expected ${"$"}JVM_SHA256, actual ${"$"}ACTUAL_SHA256"
+                        fi
+                      fi
+
                       echo "Extracting ${"$"}JVM_TEMP_FILE to ${"$"}JVM_TARGET_DIR"
                       rm -rf "${"$"}JVM_TARGET_DIR"
                       mkdir -p "${"$"}JVM_TARGET_DIR"
@@ -192,9 +211,11 @@ class Plugin : Plugin<Project> {
                     if "%WIN_ARCH%" equ "AMD64" (
                         set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsX64JvmUrl)}\
                         set JVM_URL=${cfg.windowsX64JvmUrl.replace("%", "%%")}
+                        set JVM_SHA256=${cfg.windowsX64JvmSha256.lowercase()}
                     ) else if "%WIN_ARCH%" equ "ARM64" (
                         set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsAarch64JvmUrl)}\
                         set JVM_URL=${cfg.windowsAarch64JvmUrl.replace("%", "%%")}
+                        set JVM_SHA256=${cfg.windowsAarch64JvmSha256.lowercase()}
                     ) else (
                         echo Unknown architecture %WIN_ARCH%
                         goto fail
@@ -237,6 +258,16 @@ class Plugin : Plugin<Project> {
                             Write-Host 'Downloading %JVM_URL% to %BUILD_DIR%\%JVM_TEMP_FILE%'; ^
                             [void](New-Item '%BUILD_DIR%' -ItemType Directory -Force); ^
                             (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
+                             ^
+                            if (-not [string]::IsNullOrEmpty(${'$'}env:JVM_SHA256)) { ^
+                                ${'$'}sha256Stream = [System.IO.File]::OpenRead('%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
+                                try { ${'$'}hashBytes = [System.Security.Cryptography.SHA256]::Create().ComputeHash(${'$'}sha256Stream); } finally { ${'$'}sha256Stream.Close(); } ^
+                                ${'$'}actualSha256 = ([System.BitConverter]::ToString(${'$'}hashBytes) -replace '-', '').ToLowerInvariant(); ^
+                                if (${'$'}actualSha256 -ne ${'$'}env:JVM_SHA256) { ^
+                                    Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                                    throw ('SHA-256 mismatch for %JVM_URL%: expected ' + ${'$'}env:JVM_SHA256 + ', actual ' + ${'$'}actualSha256); ^
+                                } ^
+                            } ^
                              ^
                             Write-Host 'Extracting %BUILD_DIR%\%JVM_TEMP_FILE% to %JVM_TARGET_DIR%'; ^
                             if (Test-Path '%JVM_TARGET_DIR%') { ^

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -12,4 +12,11 @@ open class PluginExtension {
     var linuxX64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-x64_bin.tar.gz"
     var macAarch64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-aarch64_bin.tar.gz"
     var macX64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-x64_bin.tar.gz"
+    // Optional SHA-256 checksums of the archives above (empty value disables the check)
+    var windowsAarch64JvmSha256 = ""
+    var windowsX64JvmSha256 = ""
+    var linuxAarch64JvmSha256 = ""
+    var linuxX64JvmSha256 = ""
+    var macAarch64JvmSha256 = ""
+    var macX64JvmSha256 = ""
 }

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -1,6 +1,26 @@
 package me.filippov.gradle.jvm.wrapper
 
 open class PluginExtension {
+    companion object {
+        // Vendor-published SHA-256 checksums of the default JVM archives below.
+        // Used automatically when the corresponding URL is left at its default;
+        // an explicitly configured *JvmSha256 value always wins.
+        internal val defaultJvmSha256 = mapOf(
+            "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip"
+                    to "e0d9380cf3d0b5efc675664fa0db22cc9eb5d77c4fd2a132f4b58df0608593cf",
+            "https://download.oracle.com/java/25/archive/jdk-25.0.2_windows-x64_bin.zip"
+                    to "56fbc625835eaa4e96942e9d8df38ffdf6009e0062620aaf9a8b647a5cd8ec7a",
+            "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-aarch64_bin.tar.gz"
+                    to "1aaf2d46506ecdf15569d5d3f0c2295a7c18795ec7a6ee030cf19406daccd0dc",
+            "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-x64_bin.tar.gz"
+                    to "505fdcb1f172b4aad23415f0584912cff90b7d902adc5f1593894b4a8cbf7c39",
+            "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-aarch64_bin.tar.gz"
+                    to "045d17ca8a00f77d91f43a12c8a023598837acc576d0701193ccf560f62ef4b4",
+            "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-x64_bin.tar.gz"
+                    to "e4f4a4b10883c1d3a0a1cefa9cd3e4ac1ed8b8e053d12ab34adc39a6875b984d",
+        )
+    }
+
     var winJvmInstallDir: String = "%LOCALAPPDATA%\\gradle-jvm"
     var keepRosetta2: Boolean = false
     var unixJvmInstallDir: String = "${"$"}{HOME}/.local/share/gradle-jvm"

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
 import java.nio.file.Path
+import java.security.MessageDigest
 import java.util.*
 
 class PluginTest {
@@ -197,8 +198,24 @@ class PluginTest {
             isArm -> "linuxAarch64" to defaults.linuxAarch64JvmUrl
             else -> "linuxX64" to defaults.linuxX64JvmUrl
         }
-        val publishedSha256 = URI("$jvmUrl.sha256").toURL().readText()
-            .trim().split(Regex("\\s+")).first { it.matches(Regex("[0-9a-fA-F]{64}")) }
+        // Not every vendor publishes a sidecar checksum file (aka.ms links redirect
+        // unknown suffixes to a search page), so fall back to hashing the archive itself.
+        val sidecarSha256 = runCatching {
+            URI("$jvmUrl.sha256").toURL().readText()
+                .trim().split(Regex("\\s+")).firstOrNull { it.matches(Regex("[0-9a-fA-F]{64}")) }
+        }.getOrNull()
+        val publishedSha256 = sidecarSha256 ?: run {
+            val digest = MessageDigest.getInstance("SHA-256")
+            URI(jvmUrl).toURL().openStream().use { input ->
+                val buffer = ByteArray(1 shl 16)
+                while (true) {
+                    val read = input.read(buffer)
+                    if (read < 0) break
+                    digest.update(buffer, 0, read)
+                }
+            }
+            digest.digest().joinToString("") { "%02x".format(it) }
+        }
 
         fun buildScriptWithSha256(sha256: String) = withBuildScript(projectRoot) { """
             plugins {

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -4,7 +4,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.io.TempDir
+import java.net.URI
 import java.nio.file.Path
+import java.util.*
 
 class PluginTest {
     // Allows platform-specific CI (e.g. Alpine/musl) to point the tests at a compatible JDK build.
@@ -165,6 +167,71 @@ class PluginTest {
             "Expected a failure, got exit code 0:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
         (result.stdout + result.stderr).shouldContain("The lock file",
             "Expected a stale lock error:\nSTDOUT:\n${result.stdout}\nSTDERR:\n${result.stderr}\n")
+
+        repeat((0..30).count()) {
+            if (!projectRoot.exists()) {
+                return@repeat
+            }
+            Thread.sleep(1000)
+            projectRoot.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun smokeSha256Validation(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("folder with space").toFile()
+        projectRoot.mkdirs()
+        val jvmInstallDir = projectRoot.resolve("build").resolve("test-temp-dir").resolve("gradle-jvm")
+        val absJvmDir = jvmInstallDir.absolutePath.replace("\\", "\\\\")
+
+        // The JVM URL the wrapper will pick on this platform (the plugin defaults) and
+        // its published checksum from the vendor's sidecar file.
+        val defaults = PluginExtension()
+        val arch = System.getProperty("os.arch").lowercase(Locale.ENGLISH)
+        val isArm = arch == "aarch64" || arch == "arm64"
+        val (platform, jvmUrl) = when {
+            isWindows && isArm -> "windowsAarch64" to defaults.windowsAarch64JvmUrl
+            isWindows -> "windowsX64" to defaults.windowsX64JvmUrl
+            isMac && isArm -> "macAarch64" to defaults.macAarch64JvmUrl
+            isMac -> "macX64" to defaults.macX64JvmUrl
+            isArm -> "linuxAarch64" to defaults.linuxAarch64JvmUrl
+            else -> "linuxX64" to defaults.linuxX64JvmUrl
+        }
+        val publishedSha256 = URI("$jvmUrl.sha256").toURL().readText()
+            .trim().split(Regex("\\s+")).first { it.matches(Regex("[0-9a-fA-F]{64}")) }
+
+        fun buildScriptWithSha256(sha256: String) = withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                winJvmInstallDir = "$absJvmDir"
+                unixJvmInstallDir = "$absJvmDir"
+                ${platform}JvmSha256 = "$sha256"
+            }
+            tasks.register("hello") {
+                doLast {
+                    println("Hello world!")
+                }
+            }
+        """}
+
+        // A wrong checksum must fail the build with a clear error before extraction.
+        buildScriptWithSha256("0".repeat(64))
+        prepareWrapper(projectRoot)
+        val badRun = gradlew(projectRoot, "hello")
+        (badRun.exitCode != 0).shouldBeTrue(
+            "Expected a failure, got exit code 0:\nSTDOUT:\n${badRun.stdout}\nSTDERR:\n${badRun.stderr}\n")
+        (badRun.stdout + badRun.stderr).shouldContain("SHA-256 mismatch",
+            "Expected a checksum error:\nSTDOUT:\n${badRun.stdout}\nSTDERR:\n${badRun.stderr}\n")
+
+        // The correct checksum must pass; uppercase input checks normalization.
+        buildScriptWithSha256(publishedSha256.uppercase())
+        prepareWrapper(projectRoot)
+        val goodRun = gradlew(projectRoot, "hello")
+        goodRun.stdout.shouldContain("Hello world!",
+            "'Hello world!' not found in output:\nSTDOUT:\n${goodRun.stdout}\nSTDERR:\n${goodRun.stderr}\n")
+        goodRun.exitCode.shouldBe(0, "Non zero exit code:\nSTDOUT:\n${goodRun.stdout}\nSTDERR:\n${goodRun.stderr}\n")
 
         repeat((0..30).count()) {
             if (!projectRoot.exists()) {

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -179,6 +179,24 @@ class PluginTest {
     }
 
     @Test
+    fun invalidSha256FailsAtConfigurationTime(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("project").toFile()
+        projectRoot.mkdirs()
+        withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                linuxX64JvmSha256 = "not-a-checksum"
+            }
+        """}
+
+        val output = prepareWrapperExpectingFailure(projectRoot)
+        output.shouldContain("linuxX64JvmSha256",
+            "Expected a configuration error mentioning the property:\n$output")
+    }
+
+    @Test
     fun smokeSha256Validation(@TempDir tempDir: Path) {
         val projectRoot = tempDir.resolve("folder with space").toFile()
         projectRoot.mkdirs()
@@ -198,12 +216,16 @@ class PluginTest {
             isArm -> "linuxAarch64" to defaults.linuxAarch64JvmUrl
             else -> "linuxX64" to defaults.linuxX64JvmUrl
         }
-        // Not every vendor publishes a sidecar checksum file (aka.ms links redirect
-        // unknown suffixes to a search page), so fall back to hashing the archive itself.
-        val sidecarSha256 = runCatching {
-            URI("$jvmUrl.sha256").toURL().readText()
-                .trim().split(Regex("\\s+")).firstOrNull { it.matches(Regex("[0-9a-fA-F]{64}")) }
-        }.getOrNull()
+        // Oracle publishes "<url>.sha256", Microsoft "<url>.sha256sum.txt". A missing
+        // aka.ms suffix redirects to a search page, hence the size cutoff; if no sidecar
+        // yields a checksum, fall back to hashing the archive itself.
+        val sidecarSha256 = sequenceOf("$jvmUrl.sha256", "$jvmUrl.sha256sum.txt")
+            .firstNotNullOfOrNull { sidecarUrl ->
+                runCatching {
+                    URI(sidecarUrl).toURL().readText().takeIf { it.length <= 1024 }
+                        ?.trim()?.split(Regex("\\s+"))?.firstOrNull { it.matches(Regex("[0-9a-fA-F]{64}")) }
+                }.getOrNull()
+            }
         val publishedSha256 = sidecarSha256 ?: run {
             val digest = MessageDigest.getInstance("SHA-256")
             URI(jvmUrl).toURL().openStream().use { input ->

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -242,6 +242,16 @@ class PluginTest {
         (badRun.stdout + badRun.stderr).shouldContain("SHA-256 mismatch",
             "Expected a checksum error:\nSTDOUT:\n${badRun.stdout}\nSTDERR:\n${badRun.stderr}\n")
 
+        // After the failure nothing must be extracted or marked as installed,
+        // and the rejected archive must be removed.
+        val leftoverFiles = jvmInstallDir.walkTopDown().filter { it.isFile }.map { it.name }.toList()
+        leftoverFiles.none { it == ".flag" }
+            .shouldBeTrue("A .flag file survived a failed validation: $leftoverFiles")
+        leftoverFiles.none { it.startsWith("gradle-jvm") }
+            .shouldBeTrue("The rejected archive was not removed: $leftoverFiles")
+        leftoverFiles.none { it.endsWith("java") || it.endsWith("java.exe") }
+            .shouldBeTrue("The JDK was extracted despite a failed validation: $leftoverFiles")
+
         // The correct checksum must pass; uppercase input checks normalization.
         buildScriptWithSha256(publishedSha256.uppercase())
         prepareWrapper(projectRoot)

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
@@ -56,6 +56,14 @@ fun withBuildScript(projectRoot: File, withContent: () -> String) {
     projectRoot.resolve("build.gradle.kts").writeText(withContent().trimIndent())
 }
 
+fun prepareWrapperExpectingFailure(projectRoot: File): String =
+    GradleRunner.create()
+        .withProjectDir(projectRoot)
+        .withArguments(":wrapper")
+        .withPluginClasspath()
+        .buildAndFail()
+        .output
+
 fun prepareWrapper(projectRoot: File) {
     val wrapperResult = GradleRunner.create()
         .withProjectDir(projectRoot)


### PR DESCRIPTION
Closes #19.

- Six new optional extension properties (windowsX64JvmSha256, windowsAarch64JvmSha256, linuxX64JvmSha256, linuxAarch64JvmSha256, macX64JvmSha256, macAarch64JvmSha256); an empty value (the default) disables the check, so existing configurations are unaffected.
- Unix: sha256sum with a shasum -a 256 fallback (macOS), checked after download and before extraction, inside the bootstrap lock; on mismatch the archive is removed and the build fails with a clear SHA-256 mismatch error.
- Windows: hashing via the .NET SHA256 API inside the existing mutex-guarded PowerShell block (deliberately not Get-FileHash - module auto-loading breaks when gradlew.bat is launched from PowerShell 7 due to inherited PSModulePath).
- Checksums are case-insensitive (normalized at script generation).
- New smokeSha256Validation test: takes the platform default JVM URL from PluginExtension, fetches the vendor-published sidecar checksum (<url>.sha256), verifies that a wrong checksum fails before extraction and the correct one (uppercase) passes.
- README section documenting the new properties.