### PR TITLE
Migrate to Provider API and support the configuration cache (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ plugins {
 }
 ```
 After that you should call `wrapper` Gradle task to setup a wrapper and update the command-line scripts.
+
+Note: with the Kotlin DSL, the `=` assignment syntax in `jvmWrapper { }` requires Gradle 8.2 or newer;
+on older Gradle versions use `.set(...)` instead.
 By default the plugin uses Oracle JDK 25. You can configure it for your JVM distribution:
 
 Groovy edition:

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -3,7 +3,10 @@ package me.filippov.gradle.jvm.wrapper
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.wrapper.Wrapper
+import java.io.File
+import java.io.Serializable
 import java.security.MessageDigest
 
 @Suppress("unused")
@@ -17,6 +20,24 @@ class Plugin : Plugin<Project> {
         const val extensionName = "jvmWrapper"
     }
 
+    private data class ResolvedConfig(
+        val winJvmInstallDir: String,
+        val unixJvmInstallDir: String,
+        val keepRosetta2: Boolean,
+        val windowsAarch64JvmUrl: String,
+        val windowsX64JvmUrl: String,
+        val linuxAarch64JvmUrl: String,
+        val linuxX64JvmUrl: String,
+        val macAarch64JvmUrl: String,
+        val macX64JvmUrl: String,
+        val windowsAarch64JvmSha256: String,
+        val windowsX64JvmSha256: String,
+        val linuxAarch64JvmSha256: String,
+        val linuxX64JvmSha256: String,
+        val macAarch64JvmSha256: String,
+        val macX64JvmSha256: String,
+    ) : Serializable
+
     private fun String.sha256(): String {
         val md = MessageDigest.getInstance("SHA-256")
         val digest = md.digest(toByteArray())
@@ -28,342 +49,357 @@ class Plugin : Plugin<Project> {
                 "-" +
                 url.sha256().take(6)
 
-    private fun effectiveSha256(configured: String, url: String) =
-        configured.ifEmpty { PluginExtension.defaultJvmSha256[url] ?: "" }.lowercase()
-
-    private fun validateSha256Properties(cfg: PluginExtension) {
-        val sha256Format = Regex("[0-9a-fA-F]{64}")
-        mapOf(
-            "windowsAarch64JvmSha256" to cfg.windowsAarch64JvmSha256,
-            "windowsX64JvmSha256" to cfg.windowsX64JvmSha256,
-            "linuxAarch64JvmSha256" to cfg.linuxAarch64JvmSha256,
-            "linuxX64JvmSha256" to cfg.linuxX64JvmSha256,
-            "macAarch64JvmSha256" to cfg.macAarch64JvmSha256,
-            "macX64JvmSha256" to cfg.macX64JvmSha256,
-        ).forEach { (name, value) ->
-            if (value.isNotEmpty() && !value.matches(sha256Format)) {
-                throw GradleException(
-                    "jvmWrapper.$name must be a 64-character hexadecimal SHA-256 checksum, got: '$value'")
-            }
+    private fun effectiveSha256(name: String, configured: String, url: String): String {
+        if (configured.isNotEmpty() && !configured.matches(Regex("[0-9a-fA-F]{64}"))) {
+            throw GradleException(
+                "jvmWrapper.$name must be a 64-character hexadecimal SHA-256 checksum, got: '$configured'")
         }
+        return configured.ifEmpty { PluginExtension.defaultJvmSha256[url] ?: "" }.lowercase()
+    }
+
+    private fun resolveConfig(cfg: PluginExtension): ResolvedConfig {
+        val windowsAarch64JvmUrl = cfg.windowsAarch64JvmUrl.get()
+        val windowsX64JvmUrl = cfg.windowsX64JvmUrl.get()
+        val linuxAarch64JvmUrl = cfg.linuxAarch64JvmUrl.get()
+        val linuxX64JvmUrl = cfg.linuxX64JvmUrl.get()
+        val macAarch64JvmUrl = cfg.macAarch64JvmUrl.get()
+        val macX64JvmUrl = cfg.macX64JvmUrl.get()
+        return ResolvedConfig(
+            winJvmInstallDir = cfg.winJvmInstallDir.get(),
+            unixJvmInstallDir = cfg.unixJvmInstallDir.get(),
+            keepRosetta2 = cfg.keepRosetta2.get(),
+            windowsAarch64JvmUrl = windowsAarch64JvmUrl,
+            windowsX64JvmUrl = windowsX64JvmUrl,
+            linuxAarch64JvmUrl = linuxAarch64JvmUrl,
+            linuxX64JvmUrl = linuxX64JvmUrl,
+            macAarch64JvmUrl = macAarch64JvmUrl,
+            macX64JvmUrl = macX64JvmUrl,
+            windowsAarch64JvmSha256 =
+                effectiveSha256("windowsAarch64JvmSha256", cfg.windowsAarch64JvmSha256.get(), windowsAarch64JvmUrl),
+            windowsX64JvmSha256 =
+                effectiveSha256("windowsX64JvmSha256", cfg.windowsX64JvmSha256.get(), windowsX64JvmUrl),
+            linuxAarch64JvmSha256 =
+                effectiveSha256("linuxAarch64JvmSha256", cfg.linuxAarch64JvmSha256.get(), linuxAarch64JvmUrl),
+            linuxX64JvmSha256 =
+                effectiveSha256("linuxX64JvmSha256", cfg.linuxX64JvmSha256.get(), linuxX64JvmUrl),
+            macAarch64JvmSha256 =
+                effectiveSha256("macAarch64JvmSha256", cfg.macAarch64JvmSha256.get(), macAarch64JvmUrl),
+            macX64JvmSha256 =
+                effectiveSha256("macX64JvmSha256", cfg.macX64JvmSha256.get(), macX64JvmUrl),
+        )
+    }
+
+    private fun generateUnixJvmScript(c: ResolvedConfig) = """
+        # $patchedFileStartMarker
+        retry_on_error () {
+          n="${'$'}1"
+          shift
+          for _ in ${'$'}(seq 2 "${'$'}n"); do
+            "${'$'}@" 2>&1 && return || echo "WARNING: Command '${'$'}1' returned non-zero exit status ${'$'}?, try again"
+          done
+          "${'$'}@"
+        }
+        jvm_is_up_to_date () {
+          [ -n "${'$'}(ls "${'$'}JVM_TARGET_DIR" 2>/dev/null)" ] && grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null
+        }
+        KEEP_ROSETTA2=${c.keepRosetta2}
+        BUILD_DIR="${c.unixJvmInstallDir}"
+        JVM_ARCH=${'$'}(uname -m)
+        if [ "${"$"}darwin" = "true" ] && ! ${"$"}KEEP_ROSETTA2 && [ "${'$'}(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
+            JVM_ARCH=arm64
+        fi
+        JVM_TEMP_FILE=${"$"}BUILD_DIR/gradle-jvm-temp.tar.gz
+        if [ "${"$"}darwin" = "true" ]; then
+            case ${"$"}JVM_ARCH in
+            x86_64)
+                JVM_URL=${c.macX64JvmUrl}
+                JVM_SHA256=${c.macX64JvmSha256}
+                JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(c.macX64JvmUrl)}
+                ;;
+            arm64)
+                JVM_URL=${c.macAarch64JvmUrl}
+                JVM_SHA256=${c.macAarch64JvmSha256}
+                JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(c.macAarch64JvmUrl)}
+                ;;
+            *)
+                die "Unknown architecture ${"$"}JVM_ARCH"
+                ;;
+            esac
+        elif [ "${"$"}cygwin" = "true" ] || [ "${"$"}msys" = "true" ]; then
+            JVM_URL=${c.windowsX64JvmUrl}
+            JVM_SHA256=${c.windowsX64JvmSha256}
+            JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(c.windowsX64JvmUrl)}
+        else
+            JVM_ARCH=${'$'}(linux${'$'}(getconf LONG_BIT) uname -m)
+            case ${"$"}JVM_ARCH in
+                x86_64)
+                    JVM_URL=${c.linuxX64JvmUrl}
+                    JVM_SHA256=${c.linuxX64JvmSha256}
+                    JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(c.linuxX64JvmUrl)}
+                    ;;
+                aarch64)
+                    JVM_URL=${c.linuxAarch64JvmUrl}
+                    JVM_SHA256=${c.linuxAarch64JvmSha256}
+                    JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(c.linuxAarch64JvmUrl)}
+                    ;;
+                *)
+                    die "Unknown architecture ${"$"}JVM_ARCH"
+                    ;;
+                esac
+        fi
+
+        set -e
+
+        if jvm_is_up_to_date; then
+            # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
+            true
+        else
+        while true; do  # Note: emulates goto
+          mkdir -p "${"$"}BUILD_DIR"
+          LOCK_FILE=${"$"}BUILD_DIR/.gradle-jvm-lock.pid
+          TMP_LOCK_FILE=${"$"}BUILD_DIR/.tmp.${'$'}${'$'}.pid
+          echo ${'$'}${'$'} >"${"$"}TMP_LOCK_FILE"
+          LN_FAILED_COUNT=0
+          while ! ln "${"$"}TMP_LOCK_FILE" "${"$"}LOCK_FILE" 2>/dev/null; do
+            if [ ! -e "${"$"}LOCK_FILE" ]; then
+              # ln failed, but there is no lock file: either the owner has just released it
+              # (retry will succeed), or the filesystem does not support hard links.
+              LN_FAILED_COUNT=${'$'}((LN_FAILED_COUNT + 1))
+              if [ "${"$"}LN_FAILED_COUNT" -ge 10 ]; then
+                rm -f "${"$"}TMP_LOCK_FILE"
+                die "ERROR: Unable to create the lock file ${"$"}LOCK_FILE. Check that the filesystem supports hard links."
+              fi
+              sleep 1
+              continue
+            fi
+            LN_FAILED_COUNT=0
+            LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
+            while [ -n "${"$"}LOCK_OWNER" ] && kill -0 "${"$"}LOCK_OWNER" 2>/dev/null; do
+              warn "Waiting for the process ${"$"}LOCK_OWNER to finish the JVM bootstrap"
+              sleep 1
+              LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
+              # Hurry up, bootstrap is ready..
+              if jvm_is_up_to_date; then
+                rm -f "${"$"}TMP_LOCK_FILE"
+                break 3  # Note: goto out of the outer if-else block.
+              fi
+            done
+            if [ -n "${"$"}LOCK_OWNER" ] && grep -q -x "${"$"}LOCK_OWNER" "${"$"}LOCK_FILE" 2>/dev/null; then
+              die "ERROR: The lock file ${"$"}LOCK_FILE still exists on disk after the owner process ${"$"}LOCK_OWNER exited"
+            fi
+          done
+          trap 'rm -f "${"$"}LOCK_FILE"' EXIT
+          rm "${"$"}TMP_LOCK_FILE"
+          if ! jvm_is_up_to_date; then
+          echo "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
+
+          rm -f "${"$"}JVM_TEMP_FILE"
+          mkdir -p "${"$"}BUILD_DIR"
+          if command -v curl >/dev/null 2>&1; then
+              if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
+              # shellcheck disable=SC2086
+              retry_on_error 5 curl ${"$"}CURL_PROGRESS -L --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
+          elif command -v wget >/dev/null 2>&1; then
+              if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
+              retry_on_error 5 wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
+          else
+              die "ERROR: Please install wget or curl"
+          fi
+
+          if [ -n "${"$"}JVM_SHA256" ]; then
+            if command -v sha256sum >/dev/null 2>&1; then
+              ACTUAL_SHA256=${'$'}(sha256sum "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
+            elif command -v shasum >/dev/null 2>&1; then
+              ACTUAL_SHA256=${'$'}(shasum -a 256 "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
+            else
+              die "ERROR: Please install sha256sum or shasum to verify the downloaded JVM"
+            fi
+            if [ "${"$"}ACTUAL_SHA256" != "${"$"}JVM_SHA256" ]; then
+              rm -f "${"$"}JVM_TEMP_FILE"
+              die "ERROR: SHA-256 mismatch for ${"$"}JVM_URL: expected ${"$"}JVM_SHA256, actual ${"$"}ACTUAL_SHA256"
+            fi
+          fi
+
+          echo "Extracting ${"$"}JVM_TEMP_FILE to ${"$"}JVM_TARGET_DIR"
+          rm -rf "${"$"}JVM_TARGET_DIR"
+          mkdir -p "${"$"}JVM_TARGET_DIR"
+
+          case "${'$'}JVM_URL" in
+            *".zip") unzip "${"$"}JVM_TEMP_FILE" -d "${"$"}JVM_TARGET_DIR" ;;
+            *) tar -x -f "${"$"}JVM_TEMP_FILE" -C "${"$"}JVM_TARGET_DIR" ;;
+          esac
+
+          rm -f "${"$"}JVM_TEMP_FILE"
+
+          echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
+          fi
+          rm "${"$"}LOCK_FILE"
+          trap - EXIT
+          break
+        done
+        fi
+
+        JAVA_HOME=
+        for d in "${"$"}JVM_TARGET_DIR" "${"$"}JVM_TARGET_DIR"/* "${"$"}JVM_TARGET_DIR"/Contents/Home "${"$"}JVM_TARGET_DIR"/*/Contents/Home; do
+          if [ -e "${"$"}d/bin/java" ]; then
+            JAVA_HOME="${"$"}d"
+          fi
+        done
+
+        if [ '!' -e "${"$"}JAVA_HOME/bin/java" ]; then
+          die "Unable to find bin/java under ${"$"}JVM_TARGET_DIR"
+        fi
+
+        # Make it available for child processes
+        export JAVA_HOME
+
+        set +e
+
+        # $patchedFileEndMarker
+    """.trimIndent() + "\n\n"
+
+    private fun generateWinJvmScript(c: ResolvedConfig) = """
+        @rem $patchedFileStartMarker
+
+        setlocal
+        set BUILD_DIR=${c.winJvmInstallDir}
+
+        for /f "tokens=3 delims= " %%A in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "PROCESSOR_ARCHITECTURE"') do set WIN_ARCH=%%A
+        if "%WIN_ARCH%" equ "AMD64" (
+            set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(c.windowsX64JvmUrl)}\
+            set JVM_URL=${c.windowsX64JvmUrl.replace("%", "%%")}
+            set JVM_SHA256=${c.windowsX64JvmSha256}
+        ) else if "%WIN_ARCH%" equ "ARM64" (
+            set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(c.windowsAarch64JvmUrl)}\
+            set JVM_URL=${c.windowsAarch64JvmUrl.replace("%", "%%")}
+            set JVM_SHA256=${c.windowsAarch64JvmSha256}
+        ) else (
+            echo Unknown architecture %WIN_ARCH%
+            goto fail
+        )
+
+        set IS_TAR_GZ=0
+        set JVM_TEMP_FILE=gradle-jvm.zip
+
+        if /I "%JVM_URL:~-7%"==".tar.gz" (
+            set IS_TAR_GZ=1
+            set JVM_TEMP_FILE=gradle-jvm.tar.gz
+        )
+
+        set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
+        set JVM_DOWNLOAD_ATTEMPTED=0
+
+        if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
+
+        set /p CURRENT_FLAG=<"%JVM_TARGET_DIR%.flag"
+        if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
+
+        :downloadAndExtractJvm
+
+        set JVM_DOWNLOAD_ATTEMPTED=1
+
+        set DOWNLOAD_AND_EXTRACT_JVM_PS1= ^
+        Set-StrictMode -Version 3.0; ^
+        ${'$'}ErrorActionPreference = 'Stop'; ^
+         ^
+        ${'$'}createdNew = ${'$'}false; ^
+        ${'$'}lock = New-Object System.Threading.Mutex(${'$'}true, 'Global\gradle-jvm-wrapper-lock', [ref]${'$'}createdNew); ^
+        if (-not ${'$'}createdNew) { ^
+            Write-Host 'Waiting for the other process to finish the JVM bootstrap'; ^
+            try { [void]${'$'}lock.WaitOne(); } catch [System.Threading.AbandonedMutexException] { } ^
+        } ^
+         ^
+        try { ^
+            if ((Get-Content '%JVM_TARGET_DIR%.flag' -ErrorAction Ignore) -ne '%JVM_URL%') { ^
+                [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
+                Write-Host 'Downloading %JVM_URL% to %BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                [void](New-Item '%BUILD_DIR%' -ItemType Directory -Force); ^
+                (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
+                 ^
+                if (-not [string]::IsNullOrEmpty(${'$'}env:JVM_SHA256)) { ^
+                    ${'$'}sha256Stream = [System.IO.File]::OpenRead('%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
+                    try { ${'$'}hashBytes = [System.Security.Cryptography.SHA256]::Create().ComputeHash(${'$'}sha256Stream); } finally { ${'$'}sha256Stream.Close(); } ^
+                    ${'$'}actualSha256 = ([System.BitConverter]::ToString(${'$'}hashBytes) -replace '-', '').ToLowerInvariant(); ^
+                    if (${'$'}actualSha256 -ne ${'$'}env:JVM_SHA256) { ^
+                        Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                        throw ('SHA-256 mismatch for %JVM_URL%: expected ' + ${'$'}env:JVM_SHA256 + ', actual ' + ${'$'}actualSha256); ^
+                    } ^
+                } ^
+                 ^
+                Write-Host 'Extracting %BUILD_DIR%\%JVM_TEMP_FILE% to %JVM_TARGET_DIR%'; ^
+                if (Test-Path '%JVM_TARGET_DIR%') { ^
+                    Remove-Item '%JVM_TARGET_DIR%' -Recurse -Force; ^
+                } ^
+                [void](New-Item '%JVM_TARGET_DIR%' -ItemType Directory -Force); ^
+                if ('%IS_TAR_GZ%' -eq '1') { ^
+                    tar -x -f '%BUILD_DIR%\%JVM_TEMP_FILE%' -C '%JVM_TARGET_DIR%.'; ^
+                    if (${'$'}LASTEXITCODE -ne 0) { throw 'tar extraction failed'; } ^
+                } else { ^
+                    Add-Type -A 'System.IO.Compression.FileSystem'; ^
+                    [IO.Compression.ZipFile]::ExtractToDirectory('%BUILD_DIR%\%JVM_TEMP_FILE%', '%JVM_TARGET_DIR%'); ^
+                } ^
+                Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
+                 ^
+                Set-Content '%JVM_TARGET_DIR%.flag' -Value '%JVM_URL%'; ^
+            } ^
+        } ^
+        finally { ^
+            [void]${'$'}lock.ReleaseMutex(); ^
+        }
+
+        "%POWERSHELL%" -nologo -noprofile -Command %DOWNLOAD_AND_EXTRACT_JVM_PS1%
+        if errorlevel 1 goto fail
+
+        :continueWithJvm
+
+        set JAVA_HOME=
+        for /d %%d in ("%JVM_TARGET_DIR%"*) do if exist "%%d\bin\java.exe" set JAVA_HOME=%%d
+        if not exist "%JAVA_HOME%\bin\java.exe" (
+          if "%JVM_DOWNLOAD_ATTEMPTED%"=="0" (
+            DEL /F /Q "%JVM_TARGET_DIR%.flag" 2>NUL
+            goto downloadAndExtractJvm
+          )
+          echo Unable to find java.exe under %JVM_TARGET_DIR%
+          goto fail
+        )
+
+        endlocal & set JAVA_HOME=%JAVA_HOME%
+
+        @rem $patchedFileEndMarker
+    """.trimIndent() + "\n\n"
+
+    private fun patchScriptFile(scriptFile: File, jvmScript: String, placeHolder: String, logger: Logger) {
+        val content = scriptFile.readText(Charsets.UTF_8)
+        if (content.contains(patchedFileStartMarker)) {
+            logger.debug("{} is up-to-date", scriptFile)
+            return
+        }
+        logger.debug("Patch {}", scriptFile)
+        val script = if (content.contains("\r\n")) jvmScript.replace("\n", "\r\n") else jvmScript
+        scriptFile.writeText(content.replace(placeHolder, script + placeHolder), Charsets.UTF_8)
+        logger.debug("{} patched", scriptFile)
     }
 
     override fun apply(project: Project) {
         val cfg = project.extensions.create(extensionName, PluginExtension::class.java)
-        project.tasks.getByName(wrapperTaskName) {
-            val task = it as Wrapper
-            project.afterEvaluate {
-                validateSha256Properties(cfg)
-                val unixJvmScript = """
-                    # $patchedFileStartMarker
-                    retry_on_error () {
-                      n="${'$'}1"
-                      shift
-                      for _ in ${'$'}(seq 2 "${'$'}n"); do
-                        "${'$'}@" 2>&1 && return || echo "WARNING: Command '${'$'}1' returned non-zero exit status ${'$'}?, try again"
-                      done
-                      "${'$'}@"
-                    }
-                    jvm_is_up_to_date () {
-                      [ -n "${'$'}(ls "${'$'}JVM_TARGET_DIR" 2>/dev/null)" ] && grep -q -x "${'$'}JVM_URL" "${'$'}JVM_TARGET_DIR/.flag" 2>/dev/null
-                    }
-                    KEEP_ROSETTA2=${cfg.keepRosetta2}
-                    BUILD_DIR="${cfg.unixJvmInstallDir}"
-                    JVM_ARCH=${'$'}(uname -m)
-                    if [ "${"$"}darwin" = "true" ] && ! ${"$"}KEEP_ROSETTA2 && [ "${'$'}(sysctl -n sysctl.proc_translated 2>/dev/null || true)" = "1" ]; then
-                        JVM_ARCH=arm64
-                    fi
-                    JVM_TEMP_FILE=${"$"}BUILD_DIR/gradle-jvm-temp.tar.gz
-                    if [ "${"$"}darwin" = "true" ]; then
-                        case ${"$"}JVM_ARCH in
-                        x86_64)
-                            JVM_URL=${cfg.macX64JvmUrl}
-                            JVM_SHA256=${effectiveSha256(cfg.macX64JvmSha256, cfg.macX64JvmUrl)}
-                            JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macX64JvmUrl)}
-                            ;;
-                        arm64)
-                            JVM_URL=${cfg.macAarch64JvmUrl}
-                            JVM_SHA256=${effectiveSha256(cfg.macAarch64JvmSha256, cfg.macAarch64JvmUrl)}
-                            JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.macAarch64JvmUrl)}
-                            ;;
-                        *) 
-                            die "Unknown architecture ${"$"}JVM_ARCH"
-                            ;;
-                        esac
-                    elif [ "${"$"}cygwin" = "true" ] || [ "${"$"}msys" = "true" ]; then
-                        JVM_URL=${cfg.windowsX64JvmUrl}
-                        JVM_SHA256=${effectiveSha256(cfg.windowsX64JvmSha256, cfg.windowsX64JvmUrl)}
-                        JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.windowsX64JvmUrl)}
-                    else
-                        JVM_ARCH=${'$'}(linux${'$'}(getconf LONG_BIT) uname -m)
-                         case ${"$"}JVM_ARCH in
-                            x86_64)
-                                JVM_URL=${cfg.linuxX64JvmUrl}
-                                JVM_SHA256=${effectiveSha256(cfg.linuxX64JvmSha256, cfg.linuxX64JvmUrl)}
-                                JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxX64JvmUrl)}
-                                ;;
-                            aarch64)
-                                JVM_URL=${cfg.linuxAarch64JvmUrl}
-                                JVM_SHA256=${effectiveSha256(cfg.linuxAarch64JvmSha256, cfg.linuxAarch64JvmUrl)}
-                                JVM_TARGET_DIR=${"$"}BUILD_DIR/${getJvmDirName(cfg.linuxAarch64JvmUrl)}
-                                ;;
-                            *) 
-                                die "Unknown architecture ${"$"}JVM_ARCH"
-                                ;;
-                            esac
-                    fi
-            
-                    set -e
-            
-                    if jvm_is_up_to_date; then
-                        # Everything is up-to-date in ${"$"}JVM_TARGET_DIR, do nothing
-                        true
-                    else
-                    while true; do  # Note: emulates goto
-                      mkdir -p "${"$"}BUILD_DIR"
-                      LOCK_FILE=${"$"}BUILD_DIR/.gradle-jvm-lock.pid
-                      TMP_LOCK_FILE=${"$"}BUILD_DIR/.tmp.${'$'}${'$'}.pid
-                      echo ${'$'}${'$'} >"${"$"}TMP_LOCK_FILE"
-                      LN_FAILED_COUNT=0
-                      while ! ln "${"$"}TMP_LOCK_FILE" "${"$"}LOCK_FILE" 2>/dev/null; do
-                        if [ ! -e "${"$"}LOCK_FILE" ]; then
-                          # ln failed, but there is no lock file: either the owner has just released it
-                          # (retry will succeed), or the filesystem does not support hard links.
-                          LN_FAILED_COUNT=${'$'}((LN_FAILED_COUNT + 1))
-                          if [ "${"$"}LN_FAILED_COUNT" -ge 10 ]; then
-                            rm -f "${"$"}TMP_LOCK_FILE"
-                            die "ERROR: Unable to create the lock file ${"$"}LOCK_FILE. Check that the filesystem supports hard links."
-                          fi
-                          sleep 1
-                          continue
-                        fi
-                        LN_FAILED_COUNT=0
-                        LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
-                        while [ -n "${"$"}LOCK_OWNER" ] && kill -0 "${"$"}LOCK_OWNER" 2>/dev/null; do
-                          warn "Waiting for the process ${"$"}LOCK_OWNER to finish the JVM bootstrap"
-                          sleep 1
-                          LOCK_OWNER=${'$'}(cat "${"$"}LOCK_FILE" 2>/dev/null || true)
-                          # Hurry up, bootstrap is ready..
-                          if jvm_is_up_to_date; then
-                            rm -f "${"$"}TMP_LOCK_FILE"
-                            break 3  # Note: goto out of the outer if-else block.
-                          fi
-                        done
-                        if [ -n "${"$"}LOCK_OWNER" ] && grep -q -x "${"$"}LOCK_OWNER" "${"$"}LOCK_FILE" 2>/dev/null; then
-                          die "ERROR: The lock file ${"$"}LOCK_FILE still exists on disk after the owner process ${"$"}LOCK_OWNER exited"
-                        fi
-                      done
-                      trap 'rm -f "${"$"}LOCK_FILE"' EXIT
-                      rm "${"$"}TMP_LOCK_FILE"
-                      if ! jvm_is_up_to_date; then
-                      echo "Downloading ${"$"}JVM_URL to ${"$"}JVM_TEMP_FILE"
-            
-                      rm -f "${"$"}JVM_TEMP_FILE"
-                      mkdir -p "${"$"}BUILD_DIR"
-                      if command -v curl >/dev/null 2>&1; then
-                          if [ -t 1 ]; then CURL_PROGRESS="--progress-bar"; else CURL_PROGRESS="--silent --show-error"; fi
-                          # shellcheck disable=SC2086
-                          retry_on_error 5 curl ${"$"}CURL_PROGRESS -L --output "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
-                      elif command -v wget >/dev/null 2>&1; then
-                          if [ -t 1 ]; then WGET_PROGRESS=""; else WGET_PROGRESS="-nv"; fi
-                          retry_on_error 5 wget ${"$"}WGET_PROGRESS -O "${"$"}{JVM_TEMP_FILE}" "${"$"}JVM_URL"
-                      else
-                          die "ERROR: Please install wget or curl"
-                      fi
+        val unixJvmScript = project.provider { generateUnixJvmScript(resolveConfig(cfg)) }
+        val winJvmScript = project.provider { generateWinJvmScript(resolveConfig(cfg)) }
+        project.tasks.named(wrapperTaskName, Wrapper::class.java).configure { task ->
+            task.inputs.property("unixJvmScript", unixJvmScript)
+            task.inputs.property("winJvmScript", winJvmScript)
 
-                      if [ -n "${"$"}JVM_SHA256" ]; then
-                        if command -v sha256sum >/dev/null 2>&1; then
-                          ACTUAL_SHA256=${'$'}(sha256sum "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
-                        elif command -v shasum >/dev/null 2>&1; then
-                          ACTUAL_SHA256=${'$'}(shasum -a 256 "${"$"}JVM_TEMP_FILE" | cut -d' ' -f1)
-                        else
-                          die "ERROR: Please install sha256sum or shasum to verify the downloaded JVM"
-                        fi
-                        if [ "${"$"}ACTUAL_SHA256" != "${"$"}JVM_SHA256" ]; then
-                          rm -f "${"$"}JVM_TEMP_FILE"
-                          die "ERROR: SHA-256 mismatch for ${"$"}JVM_URL: expected ${"$"}JVM_SHA256, actual ${"$"}ACTUAL_SHA256"
-                        fi
-                      fi
-
-                      echo "Extracting ${"$"}JVM_TEMP_FILE to ${"$"}JVM_TARGET_DIR"
-                      rm -rf "${"$"}JVM_TARGET_DIR"
-                      mkdir -p "${"$"}JVM_TARGET_DIR"
-            
-                      case "${'$'}JVM_URL" in
-                        *".zip") unzip "${"$"}JVM_TEMP_FILE" -d "${"$"}JVM_TARGET_DIR" ;;
-                        *) tar -x -f "${"$"}JVM_TEMP_FILE" -C "${"$"}JVM_TARGET_DIR" ;;
-                      esac
-                      
-                      rm -f "${"$"}JVM_TEMP_FILE"
-            
-                      echo "${"$"}JVM_URL" >"${"$"}JVM_TARGET_DIR/.flag"
-                      fi
-                      rm "${"$"}LOCK_FILE"
-                      trap - EXIT
-                      break
-                    done
-                    fi
-            
-                    JAVA_HOME=
-                    for d in "${"$"}JVM_TARGET_DIR" "${"$"}JVM_TARGET_DIR"/* "${"$"}JVM_TARGET_DIR"/Contents/Home "${"$"}JVM_TARGET_DIR"/*/Contents/Home; do
-                      if [ -e "${"$"}d/bin/java" ]; then
-                        JAVA_HOME="${"$"}d"
-                      fi
-                    done
-                    
-                    if [ '!' -e "${"$"}JAVA_HOME/bin/java" ]; then
-                      die "Unable to find bin/java under ${"$"}JVM_TARGET_DIR"
-                    fi
-                    
-                    # Make it available for child processes
-                    export JAVA_HOME
-            
-                    set +e
-                    
-                    # $patchedFileEndMarker
-                """.trimIndent() + "\n\n"
-
-                val winJvmScript = """
-                    @rem $patchedFileStartMarker
-
-                    setlocal
-                    set BUILD_DIR=${cfg.winJvmInstallDir}
-
-                    for /f "tokens=3 delims= " %%A in ('reg query "HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" /v "PROCESSOR_ARCHITECTURE"') do set WIN_ARCH=%%A
-                    if "%WIN_ARCH%" equ "AMD64" (
-                        set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsX64JvmUrl)}\
-                        set JVM_URL=${cfg.windowsX64JvmUrl.replace("%", "%%")}
-                        set JVM_SHA256=${effectiveSha256(cfg.windowsX64JvmSha256, cfg.windowsX64JvmUrl)}
-                    ) else if "%WIN_ARCH%" equ "ARM64" (
-                        set JVM_TARGET_DIR=%BUILD_DIR%\${getJvmDirName(cfg.windowsAarch64JvmUrl)}\
-                        set JVM_URL=${cfg.windowsAarch64JvmUrl.replace("%", "%%")}
-                        set JVM_SHA256=${effectiveSha256(cfg.windowsAarch64JvmSha256, cfg.windowsAarch64JvmUrl)}
-                    ) else (
-                        echo Unknown architecture %WIN_ARCH%
-                        goto fail
-                    )
-                    
-                    set IS_TAR_GZ=0
-                    set JVM_TEMP_FILE=gradle-jvm.zip
-                    
-                    if /I "%JVM_URL:~-7%"==".tar.gz" (
-                        set IS_TAR_GZ=1
-                        set JVM_TEMP_FILE=gradle-jvm.tar.gz
-                    )
-
-                    set POWERSHELL=%SystemRoot%\system32\WindowsPowerShell\v1.0\powershell.exe
-                    set JVM_DOWNLOAD_ATTEMPTED=0
-
-                    if not exist "%JVM_TARGET_DIR%.flag" goto downloadAndExtractJvm
-
-                    set /p CURRENT_FLAG=<"%JVM_TARGET_DIR%.flag"
-                    if "%CURRENT_FLAG%" == "%JVM_URL%" goto continueWithJvm
-
-                    :downloadAndExtractJvm
-
-                    set JVM_DOWNLOAD_ATTEMPTED=1
-
-                    set DOWNLOAD_AND_EXTRACT_JVM_PS1= ^
-                    Set-StrictMode -Version 3.0; ^
-                    ${'$'}ErrorActionPreference = 'Stop'; ^
-                     ^
-                    ${'$'}createdNew = ${'$'}false; ^
-                    ${'$'}lock = New-Object System.Threading.Mutex(${'$'}true, 'Global\gradle-jvm-wrapper-lock', [ref]${'$'}createdNew); ^
-                    if (-not ${'$'}createdNew) { ^
-                        Write-Host 'Waiting for the other process to finish the JVM bootstrap'; ^
-                        try { [void]${'$'}lock.WaitOne(); } catch [System.Threading.AbandonedMutexException] { } ^
-                    } ^
-                     ^
-                    try { ^
-                        if ((Get-Content '%JVM_TARGET_DIR%.flag' -ErrorAction Ignore) -ne '%JVM_URL%') { ^
-                            [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
-                            Write-Host 'Downloading %JVM_URL% to %BUILD_DIR%\%JVM_TEMP_FILE%'; ^
-                            [void](New-Item '%BUILD_DIR%' -ItemType Directory -Force); ^
-                            (New-Object Net.WebClient).DownloadFile('%JVM_URL%', '%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
-                             ^
-                            if (-not [string]::IsNullOrEmpty(${'$'}env:JVM_SHA256)) { ^
-                                ${'$'}sha256Stream = [System.IO.File]::OpenRead('%BUILD_DIR%\%JVM_TEMP_FILE%'); ^
-                                try { ${'$'}hashBytes = [System.Security.Cryptography.SHA256]::Create().ComputeHash(${'$'}sha256Stream); } finally { ${'$'}sha256Stream.Close(); } ^
-                                ${'$'}actualSha256 = ([System.BitConverter]::ToString(${'$'}hashBytes) -replace '-', '').ToLowerInvariant(); ^
-                                if (${'$'}actualSha256 -ne ${'$'}env:JVM_SHA256) { ^
-                                    Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
-                                    throw ('SHA-256 mismatch for %JVM_URL%: expected ' + ${'$'}env:JVM_SHA256 + ', actual ' + ${'$'}actualSha256); ^
-                                } ^
-                            } ^
-                             ^
-                            Write-Host 'Extracting %BUILD_DIR%\%JVM_TEMP_FILE% to %JVM_TARGET_DIR%'; ^
-                            if (Test-Path '%JVM_TARGET_DIR%') { ^
-                                Remove-Item '%JVM_TARGET_DIR%' -Recurse -Force; ^
-                            } ^
-                            [void](New-Item '%JVM_TARGET_DIR%' -ItemType Directory -Force); ^
-                            if ('%IS_TAR_GZ%' -eq '1') { ^
-                                tar -x -f '%BUILD_DIR%\%JVM_TEMP_FILE%' -C '%JVM_TARGET_DIR%.'; ^
-                                if (${'$'}LASTEXITCODE -ne 0) { throw 'tar extraction failed'; } ^
-                            } else { ^
-                                Add-Type -A 'System.IO.Compression.FileSystem'; ^
-                                [IO.Compression.ZipFile]::ExtractToDirectory('%BUILD_DIR%\%JVM_TEMP_FILE%', '%JVM_TARGET_DIR%'); ^
-                            } ^
-                            Remove-Item '%BUILD_DIR%\%JVM_TEMP_FILE%'; ^
-                             ^
-                            Set-Content '%JVM_TARGET_DIR%.flag' -Value '%JVM_URL%'; ^
-                        } ^
-                    } ^
-                    finally { ^
-                        [void]${'$'}lock.ReleaseMutex(); ^
-                    }
-
-                    "%POWERSHELL%" -nologo -noprofile -Command %DOWNLOAD_AND_EXTRACT_JVM_PS1%
-                    if errorlevel 1 goto fail
-
-                    :continueWithJvm
-
-                    set JAVA_HOME=
-                    for /d %%d in ("%JVM_TARGET_DIR%"*) do if exist "%%d\bin\java.exe" set JAVA_HOME=%%d
-                    if not exist "%JAVA_HOME%\bin\java.exe" (
-                      if "%JVM_DOWNLOAD_ATTEMPTED%"=="0" (
-                        DEL /F /Q "%JVM_TARGET_DIR%.flag" 2>NUL
-                        goto downloadAndExtractJvm
-                      )
-                      echo Unable to find java.exe under %JVM_TARGET_DIR%
-                      goto fail
-                    )
-
-                    endlocal & set JAVA_HOME=%JAVA_HOME%
-
-                    @rem $patchedFileEndMarker
-                """.trimIndent() + "\n\n"
-
-                task.inputs.property("unixJvmScript", unixJvmScript)
-                task.inputs.property("winJvmScript", winJvmScript)
-
-                task.doLast {
-                    val unixScriptFile = task.scriptFile
-                    val winScriptFile = task.batchScript
-
-                    val unixScriptFileContent = unixScriptFile.readText(Charsets.UTF_8)
-                    if (!unixScriptFileContent.contains(patchedFileStartMarker)) {
-                        project.logger.debug("Patch $unixScriptFile")
-                        val newUnixScriptFileContent = unixScriptFileContent.replace(unixPatchPlaceHolder, unixJvmScript + unixPatchPlaceHolder)
-                        unixScriptFile.writeText(newUnixScriptFileContent, Charsets.UTF_8)
-                        project.logger.debug("$unixScriptFile patched")
-                    } else {
-                        project.logger.debug("$unixScriptFile is up-to-date")
-                    }
-                    val winScriptFileContent = winScriptFile.readText(Charsets.UTF_8)
-                    if (!winScriptFileContent.contains(patchedFileStartMarker)) {
-                        project.logger.debug("Patch $winScriptFile")
-                        val newWinScriptFileContent = winScriptFileContent.replace(winPatchPlaceHolder,
-                                if (winScriptFileContent.contains("\r\n")) {
-                                    winJvmScript.replace("\n", "\r\n")
-                                } else {
-                                    winJvmScript
-                                } + winPatchPlaceHolder)
-                        winScriptFile.writeText(newWinScriptFileContent, Charsets.UTF_8)
-                        project.logger.debug("$winScriptFile patched")
-                    } else {
-                        project.logger.debug("$winScriptFile is up-to-date")
-                    }
-                }
+            task.doLast {
+                val wrapper = it as Wrapper
+                patchScriptFile(
+                    wrapper.scriptFile,
+                    wrapper.inputs.properties["unixJvmScript"] as String,
+                    unixPatchPlaceHolder,
+                    wrapper.logger)
+                patchScriptFile(
+                    wrapper.batchScript,
+                    wrapper.inputs.properties["winJvmScript"] as String,
+                    winPatchPlaceHolder,
+                    wrapper.logger)
             }
         }
     }

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -1,42 +1,64 @@
 package me.filippov.gradle.jvm.wrapper
 
-open class PluginExtension {
+import org.gradle.api.provider.Property
+
+abstract class PluginExtension {
     companion object {
-        // Vendor-published SHA-256 checksums of the default JVM archives below.
+        // https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25
+        const val DEFAULT_WINDOWS_AARCH64_JVM_URL = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip"
+        // https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html
+        const val DEFAULT_WINDOWS_X64_JVM_URL = "https://download.oracle.com/java/25/archive/jdk-25.0.2_windows-x64_bin.zip"
+        const val DEFAULT_LINUX_AARCH64_JVM_URL = "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-aarch64_bin.tar.gz"
+        const val DEFAULT_LINUX_X64_JVM_URL = "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-x64_bin.tar.gz"
+        const val DEFAULT_MAC_AARCH64_JVM_URL = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-aarch64_bin.tar.gz"
+        const val DEFAULT_MAC_X64_JVM_URL = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-x64_bin.tar.gz"
+
+        // Vendor-published SHA-256 checksums of the default JVM archives above.
         // Used automatically when the corresponding URL is left at its default;
         // an explicitly configured *JvmSha256 value always wins.
         internal val defaultJvmSha256 = mapOf(
-            "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip"
-                    to "e0d9380cf3d0b5efc675664fa0db22cc9eb5d77c4fd2a132f4b58df0608593cf",
-            "https://download.oracle.com/java/25/archive/jdk-25.0.2_windows-x64_bin.zip"
-                    to "56fbc625835eaa4e96942e9d8df38ffdf6009e0062620aaf9a8b647a5cd8ec7a",
-            "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-aarch64_bin.tar.gz"
-                    to "1aaf2d46506ecdf15569d5d3f0c2295a7c18795ec7a6ee030cf19406daccd0dc",
-            "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-x64_bin.tar.gz"
-                    to "505fdcb1f172b4aad23415f0584912cff90b7d902adc5f1593894b4a8cbf7c39",
-            "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-aarch64_bin.tar.gz"
-                    to "045d17ca8a00f77d91f43a12c8a023598837acc576d0701193ccf560f62ef4b4",
-            "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-x64_bin.tar.gz"
-                    to "e4f4a4b10883c1d3a0a1cefa9cd3e4ac1ed8b8e053d12ab34adc39a6875b984d",
+            DEFAULT_WINDOWS_AARCH64_JVM_URL to "e0d9380cf3d0b5efc675664fa0db22cc9eb5d77c4fd2a132f4b58df0608593cf",
+            DEFAULT_WINDOWS_X64_JVM_URL to "56fbc625835eaa4e96942e9d8df38ffdf6009e0062620aaf9a8b647a5cd8ec7a",
+            DEFAULT_LINUX_AARCH64_JVM_URL to "1aaf2d46506ecdf15569d5d3f0c2295a7c18795ec7a6ee030cf19406daccd0dc",
+            DEFAULT_LINUX_X64_JVM_URL to "505fdcb1f172b4aad23415f0584912cff90b7d902adc5f1593894b4a8cbf7c39",
+            DEFAULT_MAC_AARCH64_JVM_URL to "045d17ca8a00f77d91f43a12c8a023598837acc576d0701193ccf560f62ef4b4",
+            DEFAULT_MAC_X64_JVM_URL to "e4f4a4b10883c1d3a0a1cefa9cd3e4ac1ed8b8e053d12ab34adc39a6875b984d",
         )
     }
 
-    var winJvmInstallDir: String = "%LOCALAPPDATA%\\gradle-jvm"
-    var keepRosetta2: Boolean = false
-    var unixJvmInstallDir: String = "${"$"}{HOME}/.local/share/gradle-jvm"
-    // https://learn.microsoft.com/en-us/java/openjdk/download#openjdk-25
-    var windowsAarch64JvmUrl = "https://aka.ms/download-jdk/microsoft-jdk-25.0.2-windows-aarch64.zip"
-    // https://www.oracle.com/java/technologies/javase/jdk25-archive-downloads.html
-    var windowsX64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_windows-x64_bin.zip"
-    var linuxAarch64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-aarch64_bin.tar.gz"
-    var linuxX64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_linux-x64_bin.tar.gz"
-    var macAarch64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-aarch64_bin.tar.gz"
-    var macX64JvmUrl = "https://download.oracle.com/java/25/archive/jdk-25.0.2_macos-x64_bin.tar.gz"
-    // Optional SHA-256 checksums of the archives above (empty value disables the check)
-    var windowsAarch64JvmSha256 = ""
-    var windowsX64JvmSha256 = ""
-    var linuxAarch64JvmSha256 = ""
-    var linuxX64JvmSha256 = ""
-    var macAarch64JvmSha256 = ""
-    var macX64JvmSha256 = ""
+    abstract val winJvmInstallDir: Property<String>
+    abstract val keepRosetta2: Property<Boolean>
+    abstract val unixJvmInstallDir: Property<String>
+    abstract val windowsAarch64JvmUrl: Property<String>
+    abstract val windowsX64JvmUrl: Property<String>
+    abstract val linuxAarch64JvmUrl: Property<String>
+    abstract val linuxX64JvmUrl: Property<String>
+    abstract val macAarch64JvmUrl: Property<String>
+    abstract val macX64JvmUrl: Property<String>
+    // Optional SHA-256 checksums of the archives above (an empty value falls back to the
+    // built-in vendor checksum for a default URL and disables the check for a custom one)
+    abstract val windowsAarch64JvmSha256: Property<String>
+    abstract val windowsX64JvmSha256: Property<String>
+    abstract val linuxAarch64JvmSha256: Property<String>
+    abstract val linuxX64JvmSha256: Property<String>
+    abstract val macAarch64JvmSha256: Property<String>
+    abstract val macX64JvmSha256: Property<String>
+
+    init {
+        winJvmInstallDir.convention("%LOCALAPPDATA%\\gradle-jvm")
+        keepRosetta2.convention(false)
+        unixJvmInstallDir.convention("${"$"}{HOME}/.local/share/gradle-jvm")
+        windowsAarch64JvmUrl.convention(DEFAULT_WINDOWS_AARCH64_JVM_URL)
+        windowsX64JvmUrl.convention(DEFAULT_WINDOWS_X64_JVM_URL)
+        linuxAarch64JvmUrl.convention(DEFAULT_LINUX_AARCH64_JVM_URL)
+        linuxX64JvmUrl.convention(DEFAULT_LINUX_X64_JVM_URL)
+        macAarch64JvmUrl.convention(DEFAULT_MAC_AARCH64_JVM_URL)
+        macX64JvmUrl.convention(DEFAULT_MAC_X64_JVM_URL)
+        windowsAarch64JvmSha256.convention("")
+        windowsX64JvmSha256.convention("")
+        linuxAarch64JvmSha256.convention("")
+        linuxX64JvmSha256.convention("")
+        macAarch64JvmSha256.convention("")
+        macX64JvmSha256.convention("")
+    }
 }

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -179,6 +179,29 @@ class PluginTest {
     }
 
     @Test
+    fun wrapperTaskSupportsConfigurationCache(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("project").toFile()
+        projectRoot.mkdirs()
+        withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                winJvmInstallDir = "build\\test-temp-dir\\gradle-jvm"
+                unixJvmInstallDir = "build/test-temp-dir/gradle-jvm"
+            }
+        """}
+
+        val firstRun = prepareWrapperWithArguments(projectRoot, ":wrapper", "--configuration-cache")
+        firstRun.shouldContain("Configuration cache entry stored",
+            "Expected the first run to store a configuration cache entry:\n$firstRun")
+
+        val secondRun = prepareWrapperWithArguments(projectRoot, ":wrapper", "--configuration-cache")
+        secondRun.shouldContain("Reusing configuration cache",
+            "Expected the second run to reuse the configuration cache:\n$secondRun")
+    }
+
+    @Test
     fun invalidSha256FailsAtConfigurationTime(@TempDir tempDir: Path) {
         val projectRoot = tempDir.resolve("project").toFile()
         projectRoot.mkdirs()
@@ -205,16 +228,15 @@ class PluginTest {
 
         // The JVM URL the wrapper will pick on this platform (the plugin defaults) and
         // its published checksum from the vendor's sidecar file.
-        val defaults = PluginExtension()
         val arch = System.getProperty("os.arch").lowercase(Locale.ENGLISH)
         val isArm = arch == "aarch64" || arch == "arm64"
         val (platform, jvmUrl) = when {
-            isWindows && isArm -> "windowsAarch64" to defaults.windowsAarch64JvmUrl
-            isWindows -> "windowsX64" to defaults.windowsX64JvmUrl
-            isMac && isArm -> "macAarch64" to defaults.macAarch64JvmUrl
-            isMac -> "macX64" to defaults.macX64JvmUrl
-            isArm -> "linuxAarch64" to defaults.linuxAarch64JvmUrl
-            else -> "linuxX64" to defaults.linuxX64JvmUrl
+            isWindows && isArm -> "windowsAarch64" to PluginExtension.DEFAULT_WINDOWS_AARCH64_JVM_URL
+            isWindows -> "windowsX64" to PluginExtension.DEFAULT_WINDOWS_X64_JVM_URL
+            isMac && isArm -> "macAarch64" to PluginExtension.DEFAULT_MAC_AARCH64_JVM_URL
+            isMac -> "macX64" to PluginExtension.DEFAULT_MAC_X64_JVM_URL
+            isArm -> "linuxAarch64" to PluginExtension.DEFAULT_LINUX_AARCH64_JVM_URL
+            else -> "linuxX64" to PluginExtension.DEFAULT_LINUX_X64_JVM_URL
         }
         // Oracle publishes "<url>.sha256", Microsoft "<url>.sha256sum.txt". A missing
         // aka.ms suffix redirects to a search page, hence the size cutoff; if no sidecar

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
@@ -56,6 +56,14 @@ fun withBuildScript(projectRoot: File, withContent: () -> String) {
     projectRoot.resolve("build.gradle.kts").writeText(withContent().trimIndent())
 }
 
+fun prepareWrapperWithArguments(projectRoot: File, vararg arguments: String): String =
+    GradleRunner.create()
+        .withProjectDir(projectRoot)
+        .withArguments(*arguments)
+        .withPluginClasspath()
+        .build()
+        .output
+
 fun prepareWrapperExpectingFailure(projectRoot: File): String =
     GradleRunner.create()
         .withProjectDir(projectRoot)


### PR DESCRIPTION
Closes #47.

- PluginExtension is now an abstract class with managed Property<String>/Property<Boolean> fields and conventions; default JVM URLs are exposed as public constants.
- The plugin no longer uses project.afterEvaluate: the generated script content is a lazy Provider resolved when the wrapper task inputs are fingerprinted, so late extension configuration is no longer silently ignored.
- The wrapper task is configuration cache compatible: doLast reads resolved values from task.inputs.properties and logs via the task logger; nothing from the configuration phase is captured. Covered by a new test asserting both 'entry stored' and 'reusing' scenarios.
- Eager tasks.getByName replaced with lazy tasks.named().configure.
- Generated scripts verified equivalent against master: gradlew.bat is byte-identical, gradlew differs only in whitespace.

Compatibility note (for release notes): with the Kotlin DSL, '=' assignment on the extension properties requires Gradle 8.2+; older Gradle versions must use .set(...). The Groovy DSL is unaffected. Code that read extension fields programmatically now sees Property<String> instead of String.