### PR TITLE
Warn or fail when the wrapper scripts are outdated (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ jvmWrapper {
 }
 ```
 
+## Outdated wrapper detection
+Changes in the `jvmWrapper { }` block only take effect after the `wrapper` task regenerates
+the command-line scripts. While `gradlew`/`gradlew.bat` are out of sync with the configuration,
+the plugin prints a warning on every build. To fail the build instead of warning, enable
+the strict mode (the `wrapper` task itself always stays runnable):
+```kotlin
+jvmWrapper {
+    failOnOutdatedWrapper = true
+}
+```
+
 ## SHA-256 validation
 The downloaded JVM archive is verified against an expected SHA-256 checksum.
 The default JVM URLs are validated out of the box: the vendor-published checksums for them

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/Plugin.kt
@@ -368,6 +368,39 @@ class Plugin : Plugin<Project> {
         @rem $patchedFileEndMarker
     """.trimIndent() + "\n\n"
 
+    private fun extractPatchedBlock(content: String): String? {
+        val start = content.indexOf(patchedFileStartMarker)
+        val end = content.indexOf(patchedFileEndMarker)
+        if (start < 0 || end < start) return null
+        return content.substring(start, end)
+    }
+
+    private fun checkWrapperScriptsUpToDate(project: Project, cfg: PluginExtension, task: Wrapper) {
+        val requestedTasks = project.gradle.startParameter.taskNames
+        if (requestedTasks.any { it == wrapperTaskName || it.endsWith(":$wrapperTaskName") }) {
+            // The wrapper is being regenerated in this build.
+            return
+        }
+        val config = resolveConfig(cfg)
+        val outdated = listOf(
+            task.scriptFile to generateUnixJvmScript(config),
+            task.batchScript to generateWinJvmScript(config),
+        ).filter { (scriptFile, expectedScript) ->
+            scriptFile.exists() &&
+                    extractPatchedBlock(scriptFile.readText(Charsets.UTF_8).replace("\r\n", "\n")) !=
+                    extractPatchedBlock(expectedScript)
+        }.map { it.first.name }
+        if (outdated.isEmpty()) {
+            return
+        }
+        val message = "The jvmWrapper configuration does not match the generated wrapper scripts " +
+                "(${outdated.joinToString(", ")}). Run the '$wrapperTaskName' task to regenerate them."
+        if (cfg.failOnOutdatedWrapper.get()) {
+            throw GradleException(message)
+        }
+        project.logger.warn(message)
+    }
+
     private fun patchScriptFile(scriptFile: File, jvmScript: String, placeHolder: String, logger: Logger) {
         val content = scriptFile.readText(Charsets.UTF_8)
         if (content.contains(patchedFileStartMarker)) {
@@ -384,6 +417,12 @@ class Plugin : Plugin<Project> {
         val cfg = project.extensions.create(extensionName, PluginExtension::class.java)
         val unixJvmScript = project.provider { generateUnixJvmScript(resolveConfig(cfg)) }
         val winJvmScript = project.provider { generateWinJvmScript(resolveConfig(cfg)) }
+        project.afterEvaluate {
+            // Configuration-time check: file reads below become build configuration inputs,
+            // so a configuration cache entry is invalidated when the scripts change.
+            checkWrapperScriptsUpToDate(
+                project, cfg, project.tasks.named(wrapperTaskName, Wrapper::class.java).get())
+        }
         project.tasks.named(wrapperTaskName, Wrapper::class.java).configure { task ->
             task.inputs.property("unixJvmScript", unixJvmScript)
             task.inputs.property("winJvmScript", winJvmScript)

--- a/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
+++ b/src/main/kotlin/me/filippov/gradle/jvm/wrapper/PluginExtension.kt
@@ -28,6 +28,9 @@ abstract class PluginExtension {
 
     abstract val winJvmInstallDir: Property<String>
     abstract val keepRosetta2: Property<Boolean>
+    // Fail the build instead of warning when the generated wrapper scripts are out of
+    // sync with this configuration (the wrapper task itself is always allowed to run)
+    abstract val failOnOutdatedWrapper: Property<Boolean>
     abstract val unixJvmInstallDir: Property<String>
     abstract val windowsAarch64JvmUrl: Property<String>
     abstract val windowsX64JvmUrl: Property<String>
@@ -47,6 +50,7 @@ abstract class PluginExtension {
     init {
         winJvmInstallDir.convention("%LOCALAPPDATA%\\gradle-jvm")
         keepRosetta2.convention(false)
+        failOnOutdatedWrapper.convention(false)
         unixJvmInstallDir.convention("${"$"}{HOME}/.local/share/gradle-jvm")
         windowsAarch64JvmUrl.convention(DEFAULT_WINDOWS_AARCH64_JVM_URL)
         windowsX64JvmUrl.convention(DEFAULT_WINDOWS_X64_JVM_URL)

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/PluginTest.kt
@@ -179,6 +179,105 @@ class PluginTest {
     }
 
     @Test
+    fun outdatedWrapperReportsWarning(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("project").toFile()
+        projectRoot.mkdirs()
+        val outdatedMessage = "does not match the generated wrapper scripts"
+        fun buildScriptWithUrl(url: String) = withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                linuxX64JvmUrl = "$url"
+            }
+        """}
+
+        // No wrapper scripts generated yet: nothing to compare, no warning.
+        buildScriptWithUrl(PluginExtension.DEFAULT_LINUX_X64_JVM_URL)
+        prepareWrapperWithArguments(projectRoot, "help")
+            .shouldNotContain(outdatedMessage, "No warning expected before the wrapper is generated")
+
+        prepareWrapper(projectRoot)
+        prepareWrapperWithArguments(projectRoot, "help")
+            .shouldNotContain(outdatedMessage, "No warning expected for an up-to-date wrapper")
+
+        // The configuration changed: every build warns until the wrapper is regenerated.
+        buildScriptWithUrl("https://example.com/custom-jdk-linux-x64.tar.gz")
+        prepareWrapperWithArguments(projectRoot, "help")
+            .shouldContain(outdatedMessage, "Expected a warning for an outdated wrapper")
+
+        prepareWrapper(projectRoot)
+        prepareWrapperWithArguments(projectRoot, "help")
+            .shouldNotContain(outdatedMessage, "No warning expected after regeneration")
+    }
+
+    @Test
+    fun outdatedWrapperFailsInStrictMode(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("project").toFile()
+        projectRoot.mkdirs()
+        fun buildScriptWithUrl(url: String) = withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                failOnOutdatedWrapper = true
+                linuxX64JvmUrl = "$url"
+            }
+        """}
+
+        buildScriptWithUrl(PluginExtension.DEFAULT_LINUX_X64_JVM_URL)
+        prepareWrapper(projectRoot)
+
+        buildScriptWithUrl("https://example.com/custom-jdk-linux-x64.tar.gz")
+        runGradleExpectingFailure(projectRoot, "help")
+            .shouldContain("does not match the generated wrapper scripts")
+
+        // The wrapper task itself must stay runnable to fix the situation.
+        prepareWrapper(projectRoot)
+        prepareWrapperWithArguments(projectRoot, "help")
+            .shouldNotContain("does not match the generated wrapper scripts")
+    }
+
+    @Test
+    fun outdatedWrapperCheckIsConfigurationCacheCompatible(@TempDir tempDir: Path) {
+        val projectRoot = tempDir.resolve("project").toFile()
+        projectRoot.mkdirs()
+        val outdatedMessage = "does not match the generated wrapper scripts"
+        fun buildScriptWithUrl(url: String) = withBuildScript(projectRoot) { """
+            plugins {
+              id("me.filippov.gradle.jvm.wrapper")
+            }
+            jvmWrapper {
+                linuxX64JvmUrl = "$url"
+            }
+        """}
+
+        buildScriptWithUrl(PluginExtension.DEFAULT_LINUX_X64_JVM_URL)
+        prepareWrapper(projectRoot)
+
+        val stored = prepareWrapperWithArguments(projectRoot, "help", "--configuration-cache")
+        stored.shouldContain("Configuration cache entry stored",
+            "Expected the check to be configuration cache compatible:\n$stored")
+        stored.shouldNotContain(outdatedMessage, "No warning expected for an up-to-date wrapper:\n$stored")
+
+        val reused = prepareWrapperWithArguments(projectRoot, "help", "--configuration-cache")
+        reused.shouldContain("Reusing configuration cache", "Expected cache reuse:\n$reused")
+
+        // A configuration change invalidates the entry and surfaces the warning.
+        buildScriptWithUrl("https://example.com/custom-jdk-linux-x64.tar.gz")
+        val invalidated = prepareWrapperWithArguments(projectRoot, "help", "--configuration-cache")
+        invalidated.shouldContain(outdatedMessage, "Expected a warning after a config change:\n$invalidated")
+
+        // Regenerating the wrapper changes the scripts; the file reads of the check are
+        // build configuration inputs, so the entry is invalidated and the check goes silent.
+        prepareWrapperWithArguments(projectRoot, "wrapper", "--configuration-cache")
+        val fixed = prepareWrapperWithArguments(projectRoot, "help", "--configuration-cache")
+        fixed.shouldContain("Configuration cache entry stored",
+            "Expected the entry to be invalidated by the regenerated scripts:\n$fixed")
+        fixed.shouldNotContain(outdatedMessage, "No warning expected after regeneration:\n$fixed")
+    }
+
+    @Test
     fun wrapperTaskSupportsConfigurationCache(@TempDir tempDir: Path) {
         val projectRoot = tempDir.resolve("project").toFile()
         projectRoot.mkdirs()

--- a/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
+++ b/src/test/kotlin/me/filippov/gradle/jvm/wrapper/Util.kt
@@ -65,9 +65,12 @@ fun prepareWrapperWithArguments(projectRoot: File, vararg arguments: String): St
         .output
 
 fun prepareWrapperExpectingFailure(projectRoot: File): String =
+    runGradleExpectingFailure(projectRoot, ":wrapper")
+
+fun runGradleExpectingFailure(projectRoot: File, vararg arguments: String): String =
     GradleRunner.create()
         .withProjectDir(projectRoot)
-        .withArguments(":wrapper")
+        .withArguments(*arguments)
         .withPluginClasspath()
         .buildAndFail()
         .output


### PR DESCRIPTION
Closes #21.

- On every build the plugin compares the marker-delimited block in gradlew/gradlew.bat with the block generated from the current jvmWrapper configuration (CRLF-normalized). On mismatch it warns: 'The jvmWrapper configuration does not match the generated wrapper scripts (...). Run the wrapper task to regenerate them.'
- New failOnOutdatedWrapper option (default false) turns the warning into a build failure. The wrapper task itself is always exempt, so the fix path stays runnable.
- Missing scripts (wrapper never generated) are silent; scripts without markers are reported as outdated.
- Configuration cache: verified end-to-end - the check produces no CC problems; its file reads are tracked as build configuration inputs, so entries are invalidated both by build script changes and by regenerated wrapper scripts (observed 'cannot be reused because file gradlew has changed'). Covered by a dedicated test walking through store/reuse/config change/regeneration. Known trade-off: on cache reuse the warning is not re-printed (configuration phase is skipped), so the warning appears once per configuration change; strict mode fails on every run.
- Release notes: after upgrading the plugin, users will see this warning once until they rerun the wrapper task - that is the intended signal that the generated scripts are outdated.